### PR TITLE
Set properties such that pdbs are embedded in the dll and sourcelink tests pass

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project ToolsVersion="15.0">
+    <PropertyGroup>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <DebugType>embedded</DebugType>
+        <OtherFlags>$(OtherFlags) --warnon:3390</OtherFlags>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    </PropertyGroup>
+</Project>

--- a/src/Ionide.ProjInfo.FCS/paket.references
+++ b/src/Ionide.ProjInfo.FCS/paket.references
@@ -1,2 +1,3 @@
 FSharp.Core
 FSharp.Compiler.Service
+Microsoft.SourceLink.GitHub

--- a/src/Ionide.ProjInfo.ProjectSystem/paket.references
+++ b/src/Ionide.ProjInfo.ProjectSystem/paket.references
@@ -1,3 +1,4 @@
 FSharp.Core
 FSharp.Compiler.Service
 Newtonsoft.Json
+Microsoft.SourceLink.GitHub

--- a/src/Ionide.ProjInfo.Sln/FileUtilities.cs
+++ b/src/Ionide.ProjInfo.Sln/FileUtilities.cs
@@ -6,6 +6,9 @@ using System.IO;
 
 namespace Ionide.ProjInfo.Sln.Shared
 {
+    ///<summary>
+    /// A collection of utils for safer handling of file names and paths
+    ///</summary>
     public static class FileUtilities
     {
         /// <summary>

--- a/src/Ionide.ProjInfo.Sln/Ionide.ProjInfo.Sln.csproj
+++ b/src/Ionide.ProjInfo.Sln/Ionide.ProjInfo.Sln.csproj
@@ -6,4 +6,8 @@
     <DefineConstants>FULL_SLN_PARSER;STANDALONEBUILD;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.Github" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/src/Ionide.ProjInfo/paket.references
+++ b/src/Ionide.ProjInfo/paket.references
@@ -1,3 +1,4 @@
 Microsoft.Build
 Microsoft.Build.Locator
 FSharp.Core
+Microsoft.SourceLink.GitHub


### PR DESCRIPTION
This sets a few properties for all the published projects so that sourcelink works. The core issue was that the pdbs weren't included in the package (and they contain the sourcelink information), but I sidestepped this by embedding them in the DLL. Much simpler that way.

After this change, if you run `sourcelink test <path to generated nuget>.nupkg` for any of the nuget packages in this project, the sourcelink tests will pass.