### PR TITLE
 Fix .net sdk 5.0.200 and up cracking error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.0] - 2021-03-03
+
+### Changed
+
+- Added debouncing of project-cracking to prevent rework
+- Changed the target of the build from "CoreCompile" to "Build" to bring in SDK props
+
 ## [0.48.0] - 2021-02-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.47.0] - 2021-02-10
+## [0.48.0] - 2021-02-10
 
 ### Changed
 
 - Updated to FCS 39.0.0
+
 ## [0.46.0] - 2021-01-11
 
 ### Added

--- a/build.fsx
+++ b/build.fsx
@@ -75,9 +75,10 @@ let exec cmd args dir =
         CreateProcess.fromRawCommandLine cmd args
         |> CreateProcess.ensureExitCodeWithMessage (sprintf "Error while running '%s' with args: %s" cmd args)
 
-    (if isNullOrWhiteSpace dir
-     then proc
-     else proc |> CreateProcess.withWorkingDirectory dir)
+    (if isNullOrWhiteSpace dir then
+         proc
+     else
+         proc |> CreateProcess.withWorkingDirectory dir)
     |> Proc.run
     |> ignore
 

--- a/src/Ionide.ProjInfo/Utils.fs
+++ b/src/Ionide.ProjInfo/Utils.fs
@@ -1,19 +1,32 @@
 namespace Ionide.ProjInfo
 
+module internal Paths =
+    /// provides the path to the `dotnet` binary running this library, duplicated from
+    /// https://github.com/dotnet/sdk/blob/b91b88aec2684e3d2988df8d838d3aa3c6240a35/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs#L39
+    let dotnetRoot =
+        System
+            .Diagnostics
+            .Process
+            .GetCurrentProcess()
+            .MainModule
+            .FileName
+
 module internal CommonHelpers =
 
     let chooseByPrefix (prefix: string) (s: string) =
-        if s.StartsWith(prefix)
-        then Some(s.Substring(prefix.Length))
-        else None
+        if s.StartsWith(prefix) then
+            Some(s.Substring(prefix.Length))
+        else
+            None
 
     let chooseByPrefix2 prefixes (s: string) =
         prefixes |> List.tryPick (fun prefix -> chooseByPrefix prefix s)
 
     let splitByPrefix (prefix: string) (s: string) =
-        if s.StartsWith(prefix)
-        then Some(prefix, s.Substring(prefix.Length))
-        else None
+        if s.StartsWith(prefix) then
+            Some(prefix, s.Substring(prefix.Length))
+        else
+            None
 
     let splitByPrefix2 prefixes (s: string) =
         prefixes |> List.tryPick (fun prefix -> splitByPrefix prefix s)
@@ -34,9 +47,10 @@ module internal FscArguments =
     let private outputFileArg = [ "--out:"; "-o:" ]
 
     let private makeAbs (projDir: string) (f: string) =
-        if Path.IsPathRooted f
-        then f
-        else Path.Combine(projDir, f)
+        if Path.IsPathRooted f then
+            f
+        else
+            Path.Combine(projDir, f)
 
     let outputFile projDir rsp =
         rsp |> List.tryPick (chooseByPrefix2 outputFileArg) |> Option.map (makeAbs projDir)
@@ -53,9 +67,10 @@ module internal FscArguments =
         match s |> splitByPrefix2 outputFileArg with
         | Some (prefix, v) -> prefix + (v |> makeAbs projDir)
         | None ->
-            if isCompileFile s
-            then s |> makeAbs projDir |> Path.GetFullPath
-            else s
+            if isCompileFile s then
+                s |> makeAbs projDir |> Path.GetFullPath
+            else
+                s
 
     let isTempFile (name: string) =
         let tempPath = System.IO.Path.GetTempPath()
@@ -67,9 +82,10 @@ module internal FscArguments =
         (n = "--times") || (n = "--no-jit-optimize")
 
     let isSourceFile (file: string): (string -> bool) =
-        if System.IO.Path.GetExtension(file) = ".fsproj"
-        then isCompileFile
-        else (fun n -> n.EndsWith ".cs")
+        if System.IO.Path.GetExtension(file) = ".fsproj" then
+            isCompileFile
+        else
+            (fun n -> n.EndsWith ".cs")
 
 module internal CscArguments =
     open CommonHelpers
@@ -79,23 +95,26 @@ module internal CscArguments =
     let private outputFileArg = [ "--out:"; "-o:" ]
 
     let private makeAbs (projDir: string) (f: string) =
-        if Path.IsPathRooted f
-        then f
-        else Path.Combine(projDir, f)
+        if Path.IsPathRooted f then
+            f
+        else
+            Path.Combine(projDir, f)
 
     let isCompileFile (s: string) =
         let isArg = s.StartsWith("-") && s.Contains(":")
         (not isArg) && s.EndsWith(".cs")
 
     let useFullPaths projDir (s: string) =
-        if isCompileFile s
-        then s |> makeAbs projDir |> Path.GetFullPath
-        else s
+        if isCompileFile s then
+            s |> makeAbs projDir |> Path.GetFullPath
+        else
+            s
 
     let isSourceFile (file: string): (string -> bool) =
-        if System.IO.Path.GetExtension(file) = ".csproj"
-        then isCompileFile
-        else (fun n -> n.EndsWith ".fs")
+        if System.IO.Path.GetExtension(file) = ".csproj" then
+            isCompileFile
+        else
+            (fun n -> n.EndsWith ".fs")
 
     let outputFile projDir rsp =
         rsp |> List.tryPick (chooseByPrefix2 outputFileArg) |> Option.map (makeAbs projDir)


### PR DESCRIPTION
The F# targets for several versions have set some properties based on the presence of the DOTNET_HOST_PATH environment variable, which the dotnet CLI sets when `dotnet build` or `dotnet msbuild` are run.  In 5.0.200 and up, some internal default values for these properties changed that resulted in failed cracking in this library due to invalid values, which brought to light that we were never setting this environment variable. As soon as we do (using the algorithm from the dotnet CLI itself to discover the path), all of the cracking issues go away.