### PR TITLE
Update namespace references for changes in the F# compiler. SourceCodeServices -> CodeAnalysis

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,7 +6,7 @@ storage: none
 framework: net5.0
 
 nuget FSharp.Core
-nuget FSharp.Compiler.Service ~> 39.0
+nuget FSharp.Compiler.Service ~> 40.0
 nuget Argu
 
 # copy_local: true doesn't expose sourcelink as a package dependency

--- a/src/Ionide.ProjInfo.FCS/Library.fs
+++ b/src/Ionide.ProjInfo.FCS/Library.fs
@@ -1,7 +1,7 @@
 ﻿namespace Ionide.ProjInfo
 
 open Ionide.ProjInfo.Types
-open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.CodeAnalysis
 
 module FCS =
     let rec mapToFSharpProjectOptions (projectOptions: ProjectOptions) (allKnownProjects: ProjectOptions seq) : FSharpProjectOptions =

--- a/src/Ionide.ProjInfo.ProjectSystem/Project.fs
+++ b/src/Ionide.ProjInfo.ProjectSystem/Project.fs
@@ -2,7 +2,7 @@
 
 open System
 open System.IO
-open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.CodeAnalysis
 open Newtonsoft.Json
 open Ionide.ProjInfo
 

--- a/src/Ionide.ProjInfo.ProjectSystem/ProjectSystem.fs
+++ b/src/Ionide.ProjInfo.ProjectSystem/ProjectSystem.fs
@@ -3,7 +3,7 @@ namespace Ionide.ProjInfo.ProjectSystem
 open System
 open System.IO
 open System.Collections.Concurrent
-open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.CodeAnalysis
 open Ionide.ProjInfo.Types
 open Ionide.ProjInfo
 open Workspace

--- a/src/Ionide.ProjInfo.ProjectSystem/Workspace.fs
+++ b/src/Ionide.ProjInfo.ProjectSystem/Workspace.fs
@@ -9,7 +9,7 @@ type internal GetProjectOptionsErrors = Types.GetProjectOptionsErrors
 [<RequireQualifiedAccess>]
 type internal ProjectSystemState =
     | Loading of string
-    | Loaded of FSharp.Compiler.SourceCodeServices.FSharpProjectOptions * Types.ProjectOptions * ProjectViewerItem list * fromDpiCache: bool
+    | Loaded of FSharp.Compiler.CodeAnalysis.FSharpProjectOptions * Types.ProjectOptions * ProjectViewerItem list * fromDpiCache: bool
     | LoadedOther of Types.ProjectOptions * ProjectViewerItem list * fromDpiCache: bool
     | Failed of string * GetProjectOptionsErrors
 

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -11,7 +11,7 @@ open System.Collections.Generic
 open Ionide.ProjInfo.Types
 open Ionide.ProjInfo
 open Expecto.Logging.Message
-open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.CodeAnalysis
 
 #nowarn "25"
 


### PR DESCRIPTION
Trying to use `Ionide.ProjInfo.FCS.mapToFSharpProjectOptions` was throwing the error 

> The module/namespace 'FSharp.Compiler.SourceCodeServices' from compilation unit 'FSharp.Compiler.Service' did not contain the namespace, module or type 'FSharpProjectOptions'

This is because the library takes any package version >=39 but FSharp.Compiler.Service 40 [made breaking namespace changes](https://github.com/dotnet/fsharp/blob/main/release-notes.md#fsharp-compiler-service-4000). Specifically emptying out `SourceCodeServices` and moving those types elsewhere.

I think my fixes should work, but I wasn't able to get the project building locally. For some reason `Ionide.ProjInfo.Logging` is referenced, but missing.