### PR TITLE
Handle command line args in test project

### DIFF
--- a/test/Ionide.ProjInfo.Tests/Program.fs
+++ b/test/Ionide.ProjInfo.Tests/Program.fs
@@ -22,8 +22,9 @@ let main argv =
     Environment.SetEnvironmentVariable("DOTNET_HOST_PATH", IO.Path.Combine(baseDir, dotnetExe))
     let toolsPath = Init.init (IO.DirectoryInfo Environment.CurrentDirectory)
 
-    Tests.runTests
+    Tests.runTestsWithArgs
         { defaultConfig with
               printer = TestPrinters.summaryPrinter defaultConfig.printer
               verbosity = LogLevel.Info }
+        argv
         (Tests.tests toolsPath)


### PR DESCRIPTION
Currently the test project always runs all tests.

With this PR command line args are passed to expecto  
-> can filter tests (like `dotnet run -- --filter "Main tests.can load sln"` or `dotnet run -- --run "Main tests.can load sln - WorkspaceLoaderViaProjectGraph"`)
