### PR TITLE
Fix: Retrieving dotnet runtimes hangs when there are too many runtimes installed

### DIFF
--- a/src/Ionide.ProjInfo/Library.fs
+++ b/src/Ionide.ProjInfo/Library.fs
@@ -31,13 +31,18 @@ module SdkDiscovery =
             info.ArgumentList.Add arg
 
         info.RedirectStandardOutput <- true
-        let p = System.Diagnostics.Process.Start(info)
-        p.WaitForExit()
+        use p = System.Diagnostics.Process.Start(info)
 
-        seq {
-            while not p.StandardOutput.EndOfStream do
-                yield p.StandardOutput.ReadLine()
-        }
+        let output =
+            seq {
+                while not p.StandardOutput.EndOfStream do
+                    yield p.StandardOutput.ReadLine()
+            }
+            |> Seq.toArray
+
+        p.WaitForExit()
+        output
+
 
     let private (|SemVer|_|) version =
         match SemanticVersioning.Version.TryParse version with


### PR DESCRIPTION
Test `Main tests.can get runtimes` hangs on my PC.  

Reason: ProjInfo calls `dotnet --list-runtimes` by executing `dotnet`, waiting for it to finish, and then reading the output:  
https://github.com/ionide/proj-info/blob/1c9317b851571d2b53df93250e1b4491a84152af/src/Ionide.ProjInfo/Library.fs#L25-L40  

Important: First Waiting for exit, Then reading output 

But: The executing Process blocks when its output buffer is full and not read (see [Remarks for `Process.StandardOutput`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standardoutput?view=net-5.0#remarks)).  
-> When there are too many runtimes installed (-> too many lines from `--list-runtimes`), calling `dotnet --list-runtimes` hangs.

I installed at least one new dotnet version over the last days (-> several additional runtimes). Which seems to just crossed the line between "working" and "buffer full"  
(there are more runtimes than sdks -> happend with `--list-runtimes`, not (yet) with `--list-sdks`)

<br/>
<br/>
<br/>

Fix: Read lines while executing