### PR TITLE
Add additional fallback probes

### DIFF
--- a/src/Ionide.ProjInfo.Tool/Ionide.ProjInfo.Tool.fsproj
+++ b/src/Ionide.ProjInfo.Tool/Ionide.ProjInfo.Tool.fsproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net5.0</TargetFrameworks>
         <PackAsTool>true</PackAsTool>
+        <ToolCommandName>proj-info</ToolCommandName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Ionide.ProjInfo.Tool/Program.fs
+++ b/src/Ionide.ProjInfo.Tool/Program.fs
@@ -18,17 +18,21 @@ type Args =
             | Solution (path) -> "Analyze a solution of projects at {path}"
             | Graph -> "Use the graph loader"
 
-let parser = Argu.ArgumentParser.Create("proj", "analyze msbuild projects", errorHandler = ProcessExiter(), checkStructure = true)
+let parser =
+    Argu.ArgumentParser.Create("proj", "analyze msbuild projects", errorHandler = ProcessExiter(), checkStructure = true)
 
 type LoaderFunc = ToolsPath * list<string * string> -> IWorkspaceLoader
 
-let parseProject (loaderFunc: LoaderFunc) (path: string) =
+let (|Rooted|) (s: string) =
+    System.IO.Path.Combine(System.Environment.CurrentDirectory, s)
+
+let parseProject (loaderFunc: LoaderFunc) (Rooted path) =
     let cwd = System.IO.Path.GetDirectoryName path |> System.IO.DirectoryInfo
     let toolsPath = Ionide.ProjInfo.Init.init cwd None
     let loader = loaderFunc (toolsPath, [])
     loader.LoadProjects([ path ], [], BinaryLogGeneration.Within cwd)
 
-let parseSolution (loaderFunc: LoaderFunc) (path: string) =
+let parseSolution (loaderFunc: LoaderFunc) (Rooted path) =
     let cwd = System.IO.Path.GetDirectoryName path |> System.IO.DirectoryInfo
     let toolsPath = Ionide.ProjInfo.Init.init cwd None
     let loader = loaderFunc (toolsPath, [])

--- a/src/Ionide.ProjInfo/Library.fs
+++ b/src/Ionide.ProjInfo/Library.fs
@@ -180,7 +180,7 @@ module Init =
     /// Initialize the MsBuild integration. Returns path to MsBuild tool that was detected by Locator. Needs to be called before doing anything else.
     /// Call it again when the working directory changes.
     let init (workingDirectory: DirectoryInfo) (dotnetExe: FileInfo option) =
-        let exe = dotnetExe |> Option.orElseWith (fun _ -> Paths.dotnetRoot)
+        let exe = dotnetExe |> Option.orElseWith (fun _ -> Paths.dotnetRoot.Value)
 
         match exe with
         | None -> failwith "No dotnet binary could be found via the DOTNET_HOST_PATH or DOTNET_ROOT environment variables, the PATH environment variable, or the default install locations"

--- a/src/Ionide.ProjInfo/Utils.fs
+++ b/src/Ionide.ProjInfo/Utils.fs
@@ -80,7 +80,8 @@ module Paths =
     /// provides the path to the `dotnet` binary running this library, respecting various dotnet <see href="https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_root-dotnet_rootx86%5D">environment variables</see>.
     /// Also probes the PATH and checks the default installation locations
     /// </summary>
-    let dotnetRoot = tryFindFromEnvVar () |> Option.orElseWith tryFindFromPATH |> Option.orElseWith tryFindFromDefaultDirs
+    let dotnetRoot =
+        lazy (tryFindFromEnvVar () |> Option.orElseWith tryFindFromPATH |> Option.orElseWith tryFindFromDefaultDirs)
 
     let sdksPath (dotnetRoot: string) =
         System.IO.Path.Combine(dotnetRoot, "Sdks")

--- a/src/Ionide.ProjInfo/Utils.fs
+++ b/src/Ionide.ProjInfo/Utils.fs
@@ -5,7 +5,10 @@ open System.IO
 open System
 
 module Paths =
-    let private isUnix = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+    let private isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+    let private isMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+    let private isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+    let private isUnix = isLinux || isMac
 
     let private dotnetBinaryName =
         if isUnix then
@@ -24,25 +27,60 @@ module Paths =
         | "" -> None
         | other -> Some other
 
-    /// <summary>
-    /// provides the path to the `dotnet` binary running this library, respecting various dotnet <see href="https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_root-dotnet_rootx86%5D">environment variables</see>
-    /// </summary>
-    let dotnetRoot =
+    let private tryFindFromEnvVar () =
         potentialDotnetHostEnvVars
-        |> List.tryPick
-            (fun (envVar, transformer) ->
-                match Environment.GetEnvironmentVariable envVar |> existingEnvVarValue with
-                | Some varValue -> Some(transformer varValue |> FileInfo)
-                | None -> None)
-        |> Option.defaultWith
-            (fun _ ->
-                System
-                    .Diagnostics
-                    .Process
-                    .GetCurrentProcess()
-                    .MainModule
-                    .FileName
-                |> FileInfo)
+        |> List.tryPick (fun (envVar, transformer) ->
+            match Environment.GetEnvironmentVariable envVar |> existingEnvVarValue with
+            | Some varValue -> Some(transformer varValue |> FileInfo)
+            | None -> None)
+
+    let private PATHSeparator =
+        if isUnix then
+            ':'
+        else
+            ';'
+
+    let private tryFindFromPATH () =
+        System
+            .Environment
+            .GetEnvironmentVariable("PATH")
+            .Split(PATHSeparator, StringSplitOptions.RemoveEmptyEntries ||| StringSplitOptions.TrimEntries)
+        |> Array.tryPick (fun d ->
+            let fi = Path.Combine(d, dotnetBinaryName) |> FileInfo
+
+            if fi.Exists then
+                Some fi
+            else
+                None)
+
+
+    let private tryFindFromDefaultDirs () =
+        let windowsPath = $"C:\\Program Files\\dotnet\\{dotnetBinaryName}"
+        let macosPath = $"/usr/local/share/dotnet/{dotnetBinaryName}"
+        let linuxPath = $"/usr/share/dotnet/{dotnetBinaryName}"
+
+        let tryFindFile p =
+            let f = FileInfo p
+
+            if f.Exists then
+                Some f
+            else
+                None
+
+        if isWindows then
+            tryFindFile windowsPath
+        else if isMac then
+            tryFindFile macosPath
+        else if isLinux then
+            tryFindFile linuxPath
+        else
+            None
+
+    /// <summary>
+    /// provides the path to the `dotnet` binary running this library, respecting various dotnet <see href="https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_root-dotnet_rootx86%5D">environment variables</see>.
+    /// Also probes the PATH and checks the default installation locations
+    /// </summary>
+    let dotnetRoot = tryFindFromEnvVar () |> Option.orElseWith tryFindFromPATH |> Option.orElseWith tryFindFromDefaultDirs
 
     let sdksPath (dotnetRoot: string) =
         System.IO.Path.Combine(dotnetRoot, "Sdks")

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -1038,10 +1038,10 @@ let tests toolsPath =
           testSample2WithBinLog toolsPath "WorkspaceLoader" WorkspaceLoader.Create
           testSample2WithBinLog toolsPath "WorkspaceLoaderViaProjectGraph" WorkspaceLoaderViaProjectGraph.Create
           test "can get runtimes" {
-              let runtimes = SdkDiscovery.runtimes Paths.dotnetRoot
+              let runtimes = SdkDiscovery.runtimes (Paths.dotnetRoot.Value |> Option.defaultWith (fun _ -> failwith "unable to find dotnet binary"))
               Expect.isNonEmpty runtimes "should have found at least the currently-executing runtime"
           }
           test "can get sdks" {
-              let sdks = SdkDiscovery.sdks Paths.dotnetRoot
+              let sdks = SdkDiscovery.sdks (Paths.dotnetRoot.Value |> Option.defaultWith (fun _ -> failwith "unable to find dotnet binary"))
               Expect.isNonEmpty sdks "should have found at least the currently-executing sdk"
           } ]

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -25,12 +25,11 @@ let checkExitCodeZero (cmd: Command) =
 
 let findByPath path parsed =
     parsed
-    |> Array.tryPick
-        (fun (kv: KeyValuePair<string, ProjectOptions>) ->
-            if kv.Key = path then
-                Some kv
-            else
-                None)
+    |> Array.tryPick (fun (kv: KeyValuePair<string, ProjectOptions>) ->
+        if kv.Key = path then
+            Some kv
+        else
+            None)
     |> function
         | Some x -> x
         | None -> failwithf "key '%s' not found in %A" path (parsed |> Array.map (fun kv -> kv.Key))
@@ -59,13 +58,11 @@ let copyDirFromAssets (fs: FileUtils) source outDir =
 let dotnet (fs: FileUtils) args = fs.shellExecRun "dotnet" args
 
 let withLog name f test =
-    test
-        name
-        (fun () ->
+    test name (fun () ->
 
-            let logger = Log.create (sprintf "Test '%s'" name)
-            let fs = FileUtils(logger)
-            f logger fs)
+        let logger = Log.create (sprintf "Test '%s'" name)
+        let fs = FileUtils(logger)
+        f logger fs)
 
 let renderOf sampleProj sources =
     { ProjectViewerTree.Name = sampleProj.ProjectFile |> Path.GetFileNameWithoutExtension
@@ -74,6 +71,13 @@ let renderOf sampleProj sources =
 let createFCS () =
     let checker = FSharpChecker.Create(projectCacheSize = 200, keepAllBackgroundResolutions = true, keepAssemblyContents = true)
     checker
+
+let sleepABit () =
+    // we wait a bit longer on macos in CI due to apparent slowness
+    if System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX) then
+        System.Threading.Thread.Sleep 5000
+    else
+        System.Threading.Thread.Sleep 3000
 
 [<AutoOpen>]
 module ExpectNotification =
@@ -113,21 +117,19 @@ module ExpectNotification =
         Expect.equal (List.length actual) (List.length expected) (sprintf "expected notifications: %A \n actual notifications: - %A" (expected |> List.map fst) (actual |> List.map getMessages))
 
         expected
-        |> List.iter
-            (fun (name, f) ->
-                let item = actual |> List.tryFind (fun a -> f a)
-                let minimal_info = item |> Option.map getMessages |> Option.defaultValue ""
-                Expect.isSome item (sprintf "expected %s but was %s" name minimal_info))
+        |> List.iter (fun (name, f) ->
+            let item = actual |> List.tryFind (fun a -> f a)
+            let minimal_info = item |> Option.map getMessages |> Option.defaultValue ""
+            Expect.isSome item (sprintf "expected %s but was %s" name minimal_info))
 
 
     type NotificationWatcher(loader: Ionide.ProjInfo.IWorkspaceLoader, log) =
         let notifications = List<_>()
 
         do
-            loader.Notifications.Add
-                (fun arg ->
-                    notifications.Add(arg)
-                    log arg)
+            loader.Notifications.Add (fun arg ->
+                notifications.Add(arg)
+                log arg)
 
         member __.Notifications = notifications |> List.ofSeq
 
@@ -139,525 +141,501 @@ module ExpectNotification =
 
 let testSample2 toolsPath workspaceLoader isRelease (workspaceFactory: ToolsPath * (string * string) list -> IWorkspaceLoader) =
     testCase
-    |> withLog
-        (sprintf "can load sample2 - %s - isRelease is %b" workspaceLoader isRelease)
-        (fun logger fs ->
-            let testDir = inDir fs "load_sample2"
-            copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir
+    |> withLog (sprintf "can load sample2 - %s - isRelease is %b" workspaceLoader isRelease) (fun logger fs ->
+        let testDir = inDir fs "load_sample2"
+        copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir
 
-            let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
-            let projDir = Path.GetDirectoryName projPath
+        let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
+        let projDir = Path.GetDirectoryName projPath
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
-            let config =
-                if isRelease then
-                    "Release"
-                else
-                    "Debug"
+        let config =
+            if isRelease then
+                "Release"
+            else
+                "Debug"
 
-            let props = [ ("Configuration", config) ]
-            let loader = workspaceFactory (toolsPath, props)
+        let props = [ ("Configuration", config) ]
+        let loader = workspaceFactory (toolsPath, props)
 
-            let watcher = watchNotifications logger loader
+        let watcher = watchNotifications logger loader
 
-            let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
 
-            [ loading "n1.fsproj"
-              loaded "n1.fsproj" ]
-            |> expectNotifications (watcher.Notifications)
+        [ loading "n1.fsproj"
+          loaded "n1.fsproj" ]
+        |> expectNotifications (watcher.Notifications)
 
-            let [ _; WorkspaceProjectState.Loaded (n1Loaded, _, _) ] = watcher.Notifications
+        let [ _; WorkspaceProjectState.Loaded (n1Loaded, _, _) ] = watcher.Notifications
 
-            let n1Parsed = parsed |> expectFind projPath "first is a lib"
+        let n1Parsed = parsed |> expectFind projPath "first is a lib"
 
-            let expectedSources =
-                [ projDir / ("obj/" + config + "/netstandard2.0/n1.AssemblyInfo.fs")
-                  projDir / "Library.fs"
-                  if isRelease then
-                      projDir / "Other.fs" ]
-                |> List.map Path.GetFullPath
+        let expectedSources =
+            [ projDir / ("obj/" + config + "/netstandard2.0/n1.AssemblyInfo.fs")
+              projDir / "Library.fs"
+              if isRelease then
+                  projDir / "Other.fs" ]
+            |> List.map Path.GetFullPath
 
-            Expect.equal parsed.Length 1 "console and lib"
-            Expect.equal n1Parsed n1Loaded "notificaton and parsed should be the same"
-            Expect.equal n1Parsed.SourceFiles expectedSources "check sources")
+        Expect.equal parsed.Length 1 "console and lib"
+        Expect.equal n1Parsed n1Loaded "notificaton and parsed should be the same"
+        Expect.equal n1Parsed.SourceFiles expectedSources "check sources")
 
 let testSample3 toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) expected =
     testCase
-    |> withLog
-        (sprintf "can load sample3 - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "load_sample3"
-            copyDirFromAssets fs ``sample3 Netsdk projs``.ProjDir testDir
+    |> withLog (sprintf "can load sample3 - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "load_sample3"
+        copyDirFromAssets fs ``sample3 Netsdk projs``.ProjDir testDir
 
-            let projPath = testDir / (``sample3 Netsdk projs``.ProjectFile)
-            let projDir = Path.GetDirectoryName projPath
+        let projPath = testDir / (``sample3 Netsdk projs``.ProjectFile)
+        let projDir = Path.GetDirectoryName projPath
 
-            let [ (l1, l1Dir); (l2, l2Dir) ] =
-                ``sample3 Netsdk projs``.ProjectReferences
-                |> List.map (fun p2p -> testDir / p2p.ProjectFile)
-                |> List.map Path.GetFullPath
-                |> List.map (fun path -> path, Path.GetDirectoryName(path))
+        let [ (l1, l1Dir); (l2, l2Dir) ] =
+            ``sample3 Netsdk projs``.ProjectReferences
+            |> List.map (fun p2p -> testDir / p2p.ProjectFile)
+            |> List.map Path.GetFullPath
+            |> List.map (fun path -> path, Path.GetDirectoryName(path))
 
-            dotnet fs [ "build"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "build"; projPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let watcher = watchNotifications logger loader
+        let watcher = watchNotifications logger loader
 
-            let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
 
-            expected |> expectNotifications (watcher.Notifications)
+        expected |> expectNotifications (watcher.Notifications)
 
 
-            let [ _; _; WorkspaceProjectState.Loaded (l1Loaded, _, _); _; WorkspaceProjectState.Loaded (l2Loaded, _, _); WorkspaceProjectState.Loaded (c1Loaded, _, _) ] = watcher.Notifications
+        let [ _; _; WorkspaceProjectState.Loaded (l1Loaded, _, _); _; WorkspaceProjectState.Loaded (l2Loaded, _, _); WorkspaceProjectState.Loaded (c1Loaded, _, _) ] =
+            watcher.Notifications
 
 
 
-            let l1Parsed = parsed |> expectFind l1 "the C# lib"
+        let l1Parsed = parsed |> expectFind l1 "the C# lib"
 
-            let l1ExpectedSources =
-                [ l1Dir / "Class1.cs"
-                  l1Dir / "obj/Debug/netstandard2.0/l1.AssemblyInfo.cs" ]
-                |> List.map Path.GetFullPath
+        let l1ExpectedSources =
+            [ l1Dir / "Class1.cs"
+              l1Dir / "obj/Debug/netstandard2.0/l1.AssemblyInfo.cs" ]
+            |> List.map Path.GetFullPath
 
-            // TODO C# doesnt have OtherOptions or SourceFiles atm. it should
-            // Expect.equal l1Parsed.SourceFiles l1ExpectedSources "check sources"
+        // TODO C# doesnt have OtherOptions or SourceFiles atm. it should
+        // Expect.equal l1Parsed.SourceFiles l1ExpectedSources "check sources"
 
-            let l2Parsed = parsed |> expectFind l2 "the F# lib"
+        let l2Parsed = parsed |> expectFind l2 "the F# lib"
 
-            let l2ExpectedSources =
-                [ l2Dir / "obj/Debug/netstandard2.0/l2.AssemblyInfo.fs"
-                  l2Dir / "Library.fs" ]
-                |> List.map Path.GetFullPath
-
-
-            let c1Parsed = parsed |> expectFind projPath "the F# console"
+        let l2ExpectedSources =
+            [ l2Dir / "obj/Debug/netstandard2.0/l2.AssemblyInfo.fs"
+              l2Dir / "Library.fs" ]
+            |> List.map Path.GetFullPath
 
 
-            let c1ExpectedSources =
-                [ projDir / "obj/Debug/netcoreapp2.1/c1.AssemblyInfo.fs"
-                  projDir / "Program.fs" ]
-                |> List.map Path.GetFullPath
+        let c1Parsed = parsed |> expectFind projPath "the F# console"
 
-            Expect.equal parsed.Length 3 (sprintf "console (F#) and lib (F#) and lib (C#), but was %A" (parsed |> List.map (fun x -> x.ProjectFileName)))
-            Expect.equal c1Parsed.SourceFiles c1ExpectedSources "check sources - C1"
-            Expect.equal l1Parsed.SourceFiles l1ExpectedSources "check sources - L1"
-            Expect.equal l2Parsed.SourceFiles l2ExpectedSources "check sources - L2"
 
-            Expect.equal l1Parsed l1Loaded "l1 notificaton and parsed should be the same"
-            Expect.equal l2Parsed l2Loaded "l2 notificaton and parsed should be the same"
-            Expect.equal c1Parsed c1Loaded "c1 notificaton and parsed should be the same")
+        let c1ExpectedSources =
+            [ projDir / "obj/Debug/netcoreapp2.1/c1.AssemblyInfo.fs"
+              projDir / "Program.fs" ]
+            |> List.map Path.GetFullPath
+
+        Expect.equal parsed.Length 3 (sprintf "console (F#) and lib (F#) and lib (C#), but was %A" (parsed |> List.map (fun x -> x.ProjectFileName)))
+        Expect.equal c1Parsed.SourceFiles c1ExpectedSources "check sources - C1"
+        Expect.equal l1Parsed.SourceFiles l1ExpectedSources "check sources - L1"
+        Expect.equal l2Parsed.SourceFiles l2ExpectedSources "check sources - L2"
+
+        Expect.equal l1Parsed l1Loaded "l1 notificaton and parsed should be the same"
+        Expect.equal l2Parsed l2Loaded "l2 notificaton and parsed should be the same"
+        Expect.equal c1Parsed c1Loaded "c1 notificaton and parsed should be the same")
 
 let testSample4 toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase
-    |> withLog
-        (sprintf "can load sample4 - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "load_sample4"
-            copyDirFromAssets fs ``sample4 NetSdk multi tfm``.ProjDir testDir
+    |> withLog (sprintf "can load sample4 - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "load_sample4"
+        copyDirFromAssets fs ``sample4 NetSdk multi tfm``.ProjDir testDir
 
-            let projPath = testDir / (``sample4 NetSdk multi tfm``.ProjectFile)
-            let projDir = Path.GetDirectoryName projPath
+        let projPath = testDir / (``sample4 NetSdk multi tfm``.ProjectFile)
+        let projDir = Path.GetDirectoryName projPath
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let watcher = watchNotifications logger loader
+        let watcher = watchNotifications logger loader
 
-            let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
 
-            [ loading "m1.fsproj"
-              loaded "m1.fsproj" ]
-            |> expectNotifications (watcher.Notifications)
+        [ loading "m1.fsproj"
+          loaded "m1.fsproj" ]
+        |> expectNotifications (watcher.Notifications)
 
-            let [ _; WorkspaceProjectState.Loaded (m1Loaded, _, _) ] = watcher.Notifications
+        let [ _; WorkspaceProjectState.Loaded (m1Loaded, _, _) ] = watcher.Notifications
 
 
-            Expect.equal parsed.Length 1 (sprintf "multi-tfm lib (F#), but was %A" (parsed |> List.map (fun x -> x.ProjectFileName)))
+        Expect.equal parsed.Length 1 (sprintf "multi-tfm lib (F#), but was %A" (parsed |> List.map (fun x -> x.ProjectFileName)))
 
-            let m1Parsed = parsed |> expectFind projPath "the F# console"
+        let m1Parsed = parsed |> expectFind projPath "the F# console"
 
-            let m1ExpectedSources =
-                [ projDir / "obj/Debug/netstandard2.0/m1.AssemblyInfo.fs"
-                  projDir / "LibraryA.fs" ]
-                |> List.map Path.GetFullPath
+        let m1ExpectedSources =
+            [ projDir / "obj/Debug/netstandard2.0/m1.AssemblyInfo.fs"
+              projDir / "LibraryA.fs" ]
+            |> List.map Path.GetFullPath
 
-            Expect.equal m1Parsed.SourceFiles m1ExpectedSources "check sources"
-            Expect.equal m1Parsed m1Loaded "m1 notificaton and parsed should be the same")
+        Expect.equal m1Parsed.SourceFiles m1ExpectedSources "check sources"
+        Expect.equal m1Parsed m1Loaded "m1 notificaton and parsed should be the same")
 
 let testSample5 toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase
-    |> withLog
-        (sprintf "can load sample5 - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "load_sample5"
-            copyDirFromAssets fs ``sample5 NetSdk CSharp library``.ProjDir testDir
+    |> withLog (sprintf "can load sample5 - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "load_sample5"
+        copyDirFromAssets fs ``sample5 NetSdk CSharp library``.ProjDir testDir
 
-            let projPath = testDir / (``sample5 NetSdk CSharp library``.ProjectFile)
-            let projDir = Path.GetDirectoryName projPath
+        let projPath = testDir / (``sample5 NetSdk CSharp library``.ProjectFile)
+        let projDir = Path.GetDirectoryName projPath
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let watcher = watchNotifications logger loader
+        let watcher = watchNotifications logger loader
 
-            let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
 
-            [ loading "l2.csproj"
-              loaded "l2.csproj" ]
-            |> expectNotifications (watcher.Notifications)
+        [ loading "l2.csproj"
+          loaded "l2.csproj" ]
+        |> expectNotifications (watcher.Notifications)
 
-            let [ _; WorkspaceProjectState.Loaded (l2Loaded, _, _) ] = watcher.Notifications
+        let [ _; WorkspaceProjectState.Loaded (l2Loaded, _, _) ] = watcher.Notifications
 
 
-            Expect.equal parsed.Length 1 "lib"
+        Expect.equal parsed.Length 1 "lib"
 
-            let l2Parsed = parsed |> expectFind projPath "a C# lib"
+        let l2Parsed = parsed |> expectFind projPath "a C# lib"
 
-            let l2ExpectedSources =
-                [ projDir / "Class1.cs"
-                  projDir / "obj/Debug/netstandard2.0/l2.AssemblyInfo.cs" ]
-                |> List.map Path.GetFullPath
+        let l2ExpectedSources =
+            [ projDir / "Class1.cs"
+              projDir / "obj/Debug/netstandard2.0/l2.AssemblyInfo.cs" ]
+            |> List.map Path.GetFullPath
 
-            // TODO C# doesnt have OtherOptions or SourceFiles atm. it should
-            // Expect.equal l2Parsed.SourceFiles l2ExpectedSources "check sources"
-            Expect.equal l2Parsed.SourceFiles l2ExpectedSources "check sources"
+        // TODO C# doesnt have OtherOptions or SourceFiles atm. it should
+        // Expect.equal l2Parsed.SourceFiles l2ExpectedSources "check sources"
+        Expect.equal l2Parsed.SourceFiles l2ExpectedSources "check sources"
 
-            Expect.equal l2Parsed l2Loaded "l2 notificaton and parsed should be the same")
+        Expect.equal l2Parsed l2Loaded "l2 notificaton and parsed should be the same")
 
 let testLoadSln toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) expected =
     testCase
-    |> withLog
-        (sprintf "can load sln - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "load_sln"
-            copyDirFromAssets fs ``sample6 Netsdk Sparse/sln``.ProjDir testDir
+    |> withLog (sprintf "can load sln - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "load_sln"
+        copyDirFromAssets fs ``sample6 Netsdk Sparse/sln``.ProjDir testDir
 
-            let slnPath = testDir / (``sample6 Netsdk Sparse/sln``.ProjectFile)
+        let slnPath = testDir / (``sample6 Netsdk Sparse/sln``.ProjectFile)
 
-            dotnet fs [ "restore"; slnPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; slnPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let watcher = watchNotifications logger loader
+        let watcher = watchNotifications logger loader
 
-            let parsed = loader.LoadSln(slnPath) |> Seq.toList
+        let parsed = loader.LoadSln(slnPath) |> Seq.toList
 
 
-            expected |> expectNotifications (watcher.Notifications)
+        expected |> expectNotifications (watcher.Notifications)
 
 
-            Expect.equal parsed.Length 3 "c1, l1, l2"
+        Expect.equal parsed.Length 3 "c1, l1, l2"
 
-            let c1 = testDir / (``sample6 Netsdk Sparse/1``.ProjectFile)
-            let c1Dir = Path.GetDirectoryName c1
+        let c1 = testDir / (``sample6 Netsdk Sparse/1``.ProjectFile)
+        let c1Dir = Path.GetDirectoryName c1
 
-            let [ l2 ] = ``sample6 Netsdk Sparse/1``.ProjectReferences |> List.map (fun p2p -> testDir / p2p.ProjectFile)
-            let l2Dir = Path.GetDirectoryName l2
+        let [ l2 ] = ``sample6 Netsdk Sparse/1``.ProjectReferences |> List.map (fun p2p -> testDir / p2p.ProjectFile)
+        let l2Dir = Path.GetDirectoryName l2
 
-            let l1 = testDir / (``sample6 Netsdk Sparse/2``.ProjectFile)
-            let l1Dir = Path.GetDirectoryName l1
+        let l1 = testDir / (``sample6 Netsdk Sparse/2``.ProjectFile)
+        let l1Dir = Path.GetDirectoryName l1
 
-            let l1Parsed = parsed |> expectFind l1 "the F# lib"
+        let l1Parsed = parsed |> expectFind l1 "the F# lib"
 
-            let l1ExpectedSources =
-                [ l1Dir / "obj/Debug/netstandard2.0/l1.AssemblyInfo.fs"
-                  l1Dir / "Library.fs" ]
-                |> List.map Path.GetFullPath
+        let l1ExpectedSources =
+            [ l1Dir / "obj/Debug/netstandard2.0/l1.AssemblyInfo.fs"
+              l1Dir / "Library.fs" ]
+            |> List.map Path.GetFullPath
 
-            Expect.equal l1Parsed.SourceFiles l1ExpectedSources "check sources l1"
-            Expect.equal l1Parsed.ReferencedProjects [] "check p2p l1"
+        Expect.equal l1Parsed.SourceFiles l1ExpectedSources "check sources l1"
+        Expect.equal l1Parsed.ReferencedProjects [] "check p2p l1"
 
-            let l2Parsed = parsed |> expectFind l2 "the C# lib"
+        let l2Parsed = parsed |> expectFind l2 "the C# lib"
 
-            let l2ExpectedSources =
-                [ l2Dir / "obj/Debug/netstandard2.0/l2.AssemblyInfo.fs"
-                  l2Dir / "Library.fs" ]
-                |> List.map Path.GetFullPath
+        let l2ExpectedSources =
+            [ l2Dir / "obj/Debug/netstandard2.0/l2.AssemblyInfo.fs"
+              l2Dir / "Library.fs" ]
+            |> List.map Path.GetFullPath
 
-            Expect.equal l2Parsed.SourceFiles l2ExpectedSources "check sources l2"
-            Expect.equal l2Parsed.ReferencedProjects [] "check p2p l2"
+        Expect.equal l2Parsed.SourceFiles l2ExpectedSources "check sources l2"
+        Expect.equal l2Parsed.ReferencedProjects [] "check p2p l2"
 
-            let c1Parsed = parsed |> expectFind c1 "the F# console"
+        let c1Parsed = parsed |> expectFind c1 "the F# console"
 
-            let c1ExpectedSources =
-                [ c1Dir / "obj/Debug/netcoreapp2.1/c1.AssemblyInfo.fs"
-                  c1Dir / "Program.fs" ]
-                |> List.map Path.GetFullPath
+        let c1ExpectedSources =
+            [ c1Dir / "obj/Debug/netcoreapp2.1/c1.AssemblyInfo.fs"
+              c1Dir / "Program.fs" ]
+            |> List.map Path.GetFullPath
 
-            Expect.equal c1Parsed.SourceFiles c1ExpectedSources "check sources c1"
-            Expect.equal c1Parsed.ReferencedProjects.Length 1 "check p2p c1"
+        Expect.equal c1Parsed.SourceFiles c1ExpectedSources "check sources c1"
+        Expect.equal c1Parsed.ReferencedProjects.Length 1 "check p2p c1"
 
-            )
+    )
 
 let testParseSln toolsPath =
     testCase
-    |> withLog
-        "can parse sln"
-        (fun logger fs ->
-            let testDir = inDir fs "parse_sln"
-            copyDirFromAssets fs ``sample6 Netsdk Sparse/sln``.ProjDir testDir
+    |> withLog "can parse sln" (fun logger fs ->
+        let testDir = inDir fs "parse_sln"
+        copyDirFromAssets fs ``sample6 Netsdk Sparse/sln``.ProjDir testDir
 
-            let slnPath = testDir / (``sample6 Netsdk Sparse/sln``.ProjectFile)
+        let slnPath = testDir / (``sample6 Netsdk Sparse/sln``.ProjectFile)
 
-            dotnet fs [ "restore"; slnPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; slnPath ] |> checkExitCodeZero
 
-            let p = InspectSln.tryParseSln (slnPath)
+        let p = InspectSln.tryParseSln (slnPath)
 
-            Expect.isTrue
-                (match p with
-                 | Ok _ -> true
-                 | Result.Error _ -> false)
-                "expected successful parse"
+        Expect.isTrue
+            (match p with
+             | Ok _ -> true
+             | Result.Error _ -> false)
+            "expected successful parse"
 
-            let actualProjects =
-                InspectSln.loadingBuildOrder (
-                    match p with
-                    | Ok (_, data) -> data
-                    | _ -> failwith "unreachable"
-                )
-                |> List.map Path.GetFullPath
-
-            let expectedProjects =
-                [ Path.Combine(testDir, "c1", "c1.fsproj")
-                  Path.Combine(testDir, "l1", "l1.fsproj")
-                  Path.Combine(testDir, "l2", "l2.fsproj") ]
-                |> List.map Path.GetFullPath
-
-            Expect.equal actualProjects expectedProjects "expected successful calculation of loading build order of solution"
-
+        let actualProjects =
+            InspectSln.loadingBuildOrder (
+                match p with
+                | Ok (_, data) -> data
+                | _ -> failwith "unreachable"
             )
+            |> List.map Path.GetFullPath
+
+        let expectedProjects =
+            [ Path.Combine(testDir, "c1", "c1.fsproj")
+              Path.Combine(testDir, "l1", "l1.fsproj")
+              Path.Combine(testDir, "l2", "l2.fsproj") ]
+            |> List.map Path.GetFullPath
+
+        Expect.equal actualProjects expectedProjects "expected successful calculation of loading build order of solution"
+
+    )
 
 let testSample9 toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase
-    |> withLog
-        (sprintf "can load sample9 - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "load_sample9"
-            copyDirFromAssets fs ``sample9 NetSdk library``.ProjDir testDir
-            // fs.cp (``sample9 NetSdk library``.ProjDir/"Directory.Build.props") testDir
+    |> withLog (sprintf "can load sample9 - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "load_sample9"
+        copyDirFromAssets fs ``sample9 NetSdk library``.ProjDir testDir
+        // fs.cp (``sample9 NetSdk library``.ProjDir/"Directory.Build.props") testDir
 
-            let projPath = testDir / (``sample9 NetSdk library``.ProjectFile)
-            let projDir = Path.GetDirectoryName projPath
+        let projPath = testDir / (``sample9 NetSdk library``.ProjectFile)
+        let projDir = Path.GetDirectoryName projPath
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let watcher = watchNotifications logger loader
+        let watcher = watchNotifications logger loader
 
-            let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
 
-            [ loading "n1.fsproj"
-              loaded "n1.fsproj" ]
-            |> expectNotifications (watcher.Notifications)
+        [ loading "n1.fsproj"
+          loaded "n1.fsproj" ]
+        |> expectNotifications (watcher.Notifications)
 
-            let [ _; WorkspaceProjectState.Loaded (n1Loaded, _, _) ] = watcher.Notifications
+        let [ _; WorkspaceProjectState.Loaded (n1Loaded, _, _) ] = watcher.Notifications
 
 
-            Expect.equal parsed.Length 1 "console and lib"
+        Expect.equal parsed.Length 1 "console and lib"
 
-            let n1Parsed = parsed |> expectFind projPath "first is a lib"
+        let n1Parsed = parsed |> expectFind projPath "first is a lib"
 
-            let expectedSources =
-                [ projDir / "obj2/Debug/netstandard2.0/n1.AssemblyInfo.fs"
-                  projDir / "Library.fs" ]
-                |> List.map Path.GetFullPath
+        let expectedSources =
+            [ projDir / "obj2/Debug/netstandard2.0/n1.AssemblyInfo.fs"
+              projDir / "Library.fs" ]
+            |> List.map Path.GetFullPath
 
-            Expect.equal n1Parsed.SourceFiles expectedSources "check sources"
+        Expect.equal n1Parsed.SourceFiles expectedSources "check sources"
 
-            Expect.equal n1Parsed n1Loaded "notificaton and parsed should be the same")
+        Expect.equal n1Parsed n1Loaded "notificaton and parsed should be the same")
 
 let testRender2 toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase
-    |> withLog
-        (sprintf "can render sample2 - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "render_sample2"
-            let sampleProj = ``sample2 NetSdk library``
-            copyDirFromAssets fs sampleProj.ProjDir testDir
+    |> withLog (sprintf "can render sample2 - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "render_sample2"
+        let sampleProj = ``sample2 NetSdk library``
+        copyDirFromAssets fs sampleProj.ProjDir testDir
 
-            let projPath = testDir / (sampleProj.ProjectFile)
-            let projDir = Path.GetDirectoryName projPath
+        let projPath = testDir / (sampleProj.ProjectFile)
+        let projDir = Path.GetDirectoryName projPath
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
 
 
-            let n1Parsed = parsed |> expectFind projPath "first is a lib"
+        let n1Parsed = parsed |> expectFind projPath "first is a lib"
 
-            let rendered = ProjectViewer.render n1Parsed
+        let rendered = ProjectViewer.render n1Parsed
 
-            let expectedSources = [ projDir / "Library.fs", "Library.fs" ] |> List.map (fun (p, l) -> Path.GetFullPath p, l)
+        let expectedSources = [ projDir / "Library.fs", "Library.fs" ] |> List.map (fun (p, l) -> Path.GetFullPath p, l)
 
-            Expect.equal rendered (renderOf sampleProj expectedSources) "check rendered project")
+        Expect.equal rendered (renderOf sampleProj expectedSources) "check rendered project")
 
 let testRender3 toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase
-    |> withLog
-        (sprintf "can render sample3 - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "render_sample3"
-            let c1Proj = ``sample3 Netsdk projs``
-            copyDirFromAssets fs c1Proj.ProjDir testDir
+    |> withLog (sprintf "can render sample3 - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "render_sample3"
+        let c1Proj = ``sample3 Netsdk projs``
+        copyDirFromAssets fs c1Proj.ProjDir testDir
 
-            let projPath = testDir / (c1Proj.ProjectFile)
-            let projDir = Path.GetDirectoryName projPath
+        let projPath = testDir / (c1Proj.ProjectFile)
+        let projDir = Path.GetDirectoryName projPath
 
-            let [ (l1Proj, l1, l1Dir); (l2Proj, l2, l2Dir) ] =
-                c1Proj.ProjectReferences
-                |> List.map (fun p2p -> p2p, Path.GetFullPath(testDir / p2p.ProjectFile))
-                |> List.map (fun (p2p, path) -> p2p, path, Path.GetDirectoryName(path))
+        let [ (l1Proj, l1, l1Dir); (l2Proj, l2, l2Dir) ] =
+            c1Proj.ProjectReferences
+            |> List.map (fun p2p -> p2p, Path.GetFullPath(testDir / p2p.ProjectFile))
+            |> List.map (fun (p2p, path) -> p2p, path, Path.GetDirectoryName(path))
 
-            dotnet fs [ "build"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "build"; projPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
 
-            let l1Parsed = parsed |> expectFind l1 "the C# lib"
+        let l1Parsed = parsed |> expectFind l1 "the C# lib"
 
-            let l2Parsed = parsed |> expectFind l2 "the F# lib"
+        let l2Parsed = parsed |> expectFind l2 "the F# lib"
 
-            let c1Parsed = parsed |> expectFind projPath "the F# console"
+        let c1Parsed = parsed |> expectFind projPath "the F# console"
 
 
-            let l1ExpectedSources =
-                [ l1Dir / "Class1.cs", "Class1.cs"
-                  l1Dir / "obj/Debug/netstandard2.0/l1.AssemblyInfo.cs", "obj/Debug/netstandard2.0/l1.AssemblyInfo.cs" ]
-                |> List.map (fun (p, l) -> Path.GetFullPath p, l)
+        let l1ExpectedSources =
+            [ l1Dir / "Class1.cs", "Class1.cs"
+              l1Dir / "obj/Debug/netstandard2.0/l1.AssemblyInfo.cs", "obj/Debug/netstandard2.0/l1.AssemblyInfo.cs" ]
+            |> List.map (fun (p, l) -> Path.GetFullPath p, l)
 
-            Expect.equal (ProjectViewer.render l1Parsed) (renderOf l1Proj l1ExpectedSources) "check rendered l1"
+        Expect.equal (ProjectViewer.render l1Parsed) (renderOf l1Proj l1ExpectedSources) "check rendered l1"
 
-            let l2ExpectedSources = [ l2Dir / "Library.fs", "Library.fs" ] |> List.map (fun (p, l) -> Path.GetFullPath p, l)
+        let l2ExpectedSources = [ l2Dir / "Library.fs", "Library.fs" ] |> List.map (fun (p, l) -> Path.GetFullPath p, l)
 
-            Expect.equal (ProjectViewer.render l2Parsed) (renderOf l2Proj l2ExpectedSources) "check rendered l2"
+        Expect.equal (ProjectViewer.render l2Parsed) (renderOf l2Proj l2ExpectedSources) "check rendered l2"
 
 
-            let c1ExpectedSources = [ projDir / "Program.fs", "Program.fs" ] |> List.map (fun (p, l) -> Path.GetFullPath p, l)
+        let c1ExpectedSources = [ projDir / "Program.fs", "Program.fs" ] |> List.map (fun (p, l) -> Path.GetFullPath p, l)
 
-            Expect.equal (ProjectViewer.render c1Parsed) (renderOf c1Proj c1ExpectedSources) "check rendered c1")
+        Expect.equal (ProjectViewer.render c1Parsed) (renderOf c1Proj c1ExpectedSources) "check rendered c1")
 
 let testRender4 toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase
-    |> withLog
-        (sprintf "can render sample4 - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "render_sample4"
-            let m1Proj = ``sample4 NetSdk multi tfm``
-            copyDirFromAssets fs m1Proj.ProjDir testDir
+    |> withLog (sprintf "can render sample4 - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "render_sample4"
+        let m1Proj = ``sample4 NetSdk multi tfm``
+        copyDirFromAssets fs m1Proj.ProjDir testDir
 
-            let projPath = testDir / (m1Proj.ProjectFile)
-            let projDir = Path.GetDirectoryName projPath
+        let projPath = testDir / (m1Proj.ProjectFile)
+        let projDir = Path.GetDirectoryName projPath
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
-            let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let loader = workspaceFactory toolsPath
+        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
 
-            let m1Parsed = parsed |> expectFind projPath "the F# console"
+        let m1Parsed = parsed |> expectFind projPath "the F# console"
 
-            let m1ExpectedSources = [ projDir / "LibraryA.fs", "LibraryA.fs" ] |> List.map (fun (p, l) -> Path.GetFullPath p, l)
+        let m1ExpectedSources = [ projDir / "LibraryA.fs", "LibraryA.fs" ] |> List.map (fun (p, l) -> Path.GetFullPath p, l)
 
-            Expect.equal (ProjectViewer.render m1Parsed) (renderOf m1Proj m1ExpectedSources) "check rendered m1")
+        Expect.equal (ProjectViewer.render m1Parsed) (renderOf m1Proj m1ExpectedSources) "check rendered m1")
 
 let testRender5 toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase
-    |> withLog
-        (sprintf "can render sample5 - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "render_sample5"
-            let l2Proj = ``sample5 NetSdk CSharp library``
-            copyDirFromAssets fs l2Proj.ProjDir testDir
+    |> withLog (sprintf "can render sample5 - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "render_sample5"
+        let l2Proj = ``sample5 NetSdk CSharp library``
+        copyDirFromAssets fs l2Proj.ProjDir testDir
 
-            let projPath = testDir / (l2Proj.ProjectFile)
-            let projDir = Path.GetDirectoryName projPath
+        let projPath = testDir / (l2Proj.ProjectFile)
+        let projDir = Path.GetDirectoryName projPath
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
 
 
-            let l2Parsed = parsed |> expectFind projPath "a C# lib"
+        let l2Parsed = parsed |> expectFind projPath "a C# lib"
 
-            let l2ExpectedSources =
-                [ projDir / "Class1.cs", "Class1.cs"
-                  projDir / "obj/Debug/netstandard2.0/l2.AssemblyInfo.cs", "obj/Debug/netstandard2.0/l2.AssemblyInfo.cs" ]
-                |> List.map (fun (p, l) -> Path.GetFullPath p, l)
+        let l2ExpectedSources =
+            [ projDir / "Class1.cs", "Class1.cs"
+              projDir / "obj/Debug/netstandard2.0/l2.AssemblyInfo.cs", "obj/Debug/netstandard2.0/l2.AssemblyInfo.cs" ]
+            |> List.map (fun (p, l) -> Path.GetFullPath p, l)
 
-            // TODO C# doesnt have OtherOptions or SourceFiles atm. it should
-            Expect.equal (ProjectViewer.render l2Parsed) (renderOf l2Proj l2ExpectedSources) "check rendered l2")
+        // TODO C# doesnt have OtherOptions or SourceFiles atm. it should
+        Expect.equal (ProjectViewer.render l2Parsed) (renderOf l2Proj l2ExpectedSources) "check rendered l2")
 
 let testRender8 toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase
-    |> withLog
-        (sprintf "can render sample8 - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "render_sample8"
-            let sampleProj = ``sample8 NetSdk Explorer``
-            copyDirFromAssets fs sampleProj.ProjDir testDir
+    |> withLog (sprintf "can render sample8 - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "render_sample8"
+        let sampleProj = ``sample8 NetSdk Explorer``
+        copyDirFromAssets fs sampleProj.ProjDir testDir
 
-            let projPath = testDir / (sampleProj.ProjectFile)
-            let projDir = Path.GetDirectoryName projPath
+        let projPath = testDir / (sampleProj.ProjectFile)
+        let projDir = Path.GetDirectoryName projPath
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
 
 
-            let n1Parsed = parsed |> expectFind projPath "first is a lib"
+        let n1Parsed = parsed |> expectFind projPath "first is a lib"
 
-            let rendered = ProjectViewer.render n1Parsed
+        let rendered = ProjectViewer.render n1Parsed
 
-            let expectedSources =
-                [ projDir / "LibraryA.fs", "Component/TheLibraryA.fs"
-                  projDir / "LibraryC.fs", "LibraryC.fs"
-                  projDir / "LibraryB.fs", "Component/Auth/TheLibraryB.fs" ]
-                |> List.map (fun (p, l) -> Path.GetFullPath p, l)
+        let expectedSources =
+            [ projDir / "LibraryA.fs", "Component/TheLibraryA.fs"
+              projDir / "LibraryC.fs", "LibraryC.fs"
+              projDir / "LibraryB.fs", "Component/Auth/TheLibraryB.fs" ]
+            |> List.map (fun (p, l) -> Path.GetFullPath p, l)
 
-            Expect.equal rendered (renderOf sampleProj expectedSources) "check rendered project")
+        Expect.equal rendered (renderOf sampleProj expectedSources) "check rendered project")
 
 let testProjectNotFound toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase
-    |> withLog
-        (sprintf "project not found - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "proj_not_found"
-            copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir
+    |> withLog (sprintf "project not found - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "proj_not_found"
+        copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir
 
-            let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
+        let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let watcher = watchNotifications logger loader
+        let watcher = watchNotifications logger loader
 
-            let wrongPath =
-                let dir, name, ext = Path.GetDirectoryName projPath, Path.GetFileNameWithoutExtension projPath, Path.GetExtension projPath
-                Path.Combine(dir, name + "aa" + ext)
+        let wrongPath =
+            let dir, name, ext = Path.GetDirectoryName projPath, Path.GetFileNameWithoutExtension projPath, Path.GetExtension projPath
+            Path.Combine(dir, name + "aa" + ext)
 
-            let parsed = loader.LoadProjects [ wrongPath ] |> Seq.toList
+        let parsed = loader.LoadProjects [ wrongPath ] |> Seq.toList
 
 
-            [ ExpectNotification.loading "n1aa.fsproj"
-              ExpectNotification.failed "n1aa.fsproj" ]
-            |> expectNotifications (watcher.Notifications)
+        [ ExpectNotification.loading "n1aa.fsproj"
+          ExpectNotification.failed "n1aa.fsproj" ]
+        |> expectNotifications (watcher.Notifications)
 
 
-            Expect.equal parsed.Length 0 "no project loaded"
+        Expect.equal parsed.Length 0 "no project loaded"
 
-            Expect.equal (watcher.Notifications |> List.item 1) (WorkspaceProjectState.Failed(wrongPath, (GetProjectOptionsErrors.ProjectNotFound(wrongPath)))) "check error type")
+        Expect.equal (watcher.Notifications |> List.item 1) (WorkspaceProjectState.Failed(wrongPath, (GetProjectOptionsErrors.ProjectNotFound(wrongPath)))) "check error type"
+    )
 
 let internalGetProjectOptions =
     fun (r: FSharpReferencedProject) ->
@@ -672,108 +650,102 @@ let internalGetProjectOptions =
 
 let testFCSmap toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase
-    |> withLog
-        (sprintf "can load sample2 with FCS - %s" workspaceLoader)
-        (fun logger fs ->
+    |> withLog (sprintf "can load sample2 with FCS - %s" workspaceLoader) (fun logger fs ->
 
-            let rec allFCSProjects (po: FSharpProjectOptions) =
-                [ yield po
-                  for reference in po.ReferencedProjects do
-                      match internalGetProjectOptions reference with
-                      | Some opts -> yield! allFCSProjects opts
-                      | None -> () ]
+        let rec allFCSProjects (po: FSharpProjectOptions) =
+            [ yield po
+              for reference in po.ReferencedProjects do
+                  match internalGetProjectOptions reference with
+                  | Some opts -> yield! allFCSProjects opts
+                  | None -> () ]
 
 
-            let rec allP2P (po: FSharpProjectOptions) =
-                [ for reference in po.ReferencedProjects do
-                      let opts = internalGetProjectOptions reference |> Option.get
-                      yield reference.FileName, opts
-                      yield! allP2P opts ]
+        let rec allP2P (po: FSharpProjectOptions) =
+            [ for reference in po.ReferencedProjects do
+                  let opts = internalGetProjectOptions reference |> Option.get
+                  yield reference.FileName, opts
+                  yield! allP2P opts ]
 
-            let expectP2PKeyIsTargetPath (pos: Map<string, ProjectOptions>) fcsPo =
-                for (tar, fcsPO) in allP2P fcsPo do
-                    let dpoPo = pos |> Map.find fcsPo.ProjectFileName
-                    Expect.equal tar dpoPo.TargetPath (sprintf "p2p key is TargetPath, fsc projet options was '%A'" fcsPO)
+        let expectP2PKeyIsTargetPath (pos: Map<string, ProjectOptions>) fcsPo =
+            for (tar, fcsPO) in allP2P fcsPo do
+                let dpoPo = pos |> Map.find fcsPo.ProjectFileName
+                Expect.equal tar dpoPo.TargetPath (sprintf "p2p key is TargetPath, fsc projet options was '%A'" fcsPO)
 
-            let testDir = inDir fs "load_sample_fsc"
-            copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir
+        let testDir = inDir fs "load_sample_fsc"
+        copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir
 
-            let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
+        let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
-            let mutable pos = Map.empty
+        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let mutable pos = Map.empty
 
-            loader.Notifications.Add
-                (function
-                | WorkspaceProjectState.Loaded (po, knownProjects, _) -> pos <- Map.add po.ProjectFileName po pos)
+        loader.Notifications.Add (function | WorkspaceProjectState.Loaded (po, knownProjects, _) -> pos <- Map.add po.ProjectFileName po pos)
 
-            let fcsPo = FCS.mapToFSharpProjectOptions parsed.Head parsed
+        let fcsPo = FCS.mapToFSharpProjectOptions parsed.Head parsed
 
-            let po = parsed |> expectFind projPath "first is a lib"
+        let po = parsed |> expectFind projPath "first is a lib"
 
-            Expect.equal fcsPo.LoadTime po.LoadTime "load time"
+        Expect.equal fcsPo.LoadTime po.LoadTime "load time"
 
-            Expect.equal fcsPo.ReferencedProjects.Length ``sample2 NetSdk library``.ProjectReferences.Length "refs"
+        Expect.equal fcsPo.ReferencedProjects.Length ``sample2 NetSdk library``.ProjectReferences.Length "refs"
 
-            //TODO check fullpaths
-            Expect.equal fcsPo.SourceFiles (po.SourceFiles |> Array.ofList) "check sources"
+        //TODO check fullpaths
+        Expect.equal fcsPo.SourceFiles (po.SourceFiles |> Array.ofList) "check sources"
 
-            expectP2PKeyIsTargetPath pos fcsPo
+        expectP2PKeyIsTargetPath pos fcsPo
 
-            let fcs = createFCS ()
-            let result = fcs.ParseAndCheckProject(fcsPo) |> Async.RunSynchronously
+        let fcs = createFCS ()
+        let result = fcs.ParseAndCheckProject(fcsPo) |> Async.RunSynchronously
 
-            Expect.isEmpty result.Diagnostics (sprintf "no errors but was: %A" result.Diagnostics)
+        Expect.isEmpty result.Diagnostics (sprintf "no errors but was: %A" result.Diagnostics)
 
-            let uses = result.GetAllUsesOfAllSymbols()
+        let uses = result.GetAllUsesOfAllSymbols()
 
-            Expect.isNonEmpty uses "all symbols usages"
+        Expect.isNonEmpty uses "all symbols usages"
 
-            )
+        )
 
 let testSample2WithBinLog toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase
-    |> withLog
-        (sprintf "can load sample2 with bin log - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "load_sample2_bin_log"
-            copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir
+    |> withLog (sprintf "can load sample2 with bin log - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "load_sample2_bin_log"
+        copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir
 
-            let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
-            let projDir = Path.GetDirectoryName projPath
+        let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
+        let projDir = Path.GetDirectoryName projPath
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let watcher = watchNotifications logger loader
+        let watcher = watchNotifications logger loader
 
-            let parsed = loader.LoadProjects([ projPath ], [], BinaryLogGeneration.Within(DirectoryInfo projDir)) |> Seq.toList
+        let parsed = loader.LoadProjects([ projPath ], [], BinaryLogGeneration.Within(DirectoryInfo projDir)) |> Seq.toList
 
-            [ loading "n1.fsproj"
-              loaded "n1.fsproj" ]
-            |> expectNotifications (watcher.Notifications)
+        [ loading "n1.fsproj"
+          loaded "n1.fsproj" ]
+        |> expectNotifications (watcher.Notifications)
 
-            let [ _; WorkspaceProjectState.Loaded (n1Loaded, _, _) ] = watcher.Notifications
+        let [ _; WorkspaceProjectState.Loaded (n1Loaded, _, _) ] = watcher.Notifications
 
-            let n1Parsed = parsed |> expectFind projPath "first is a lib"
+        let n1Parsed = parsed |> expectFind projPath "first is a lib"
 
-            let expectedSources =
-                [ projDir / "obj/Debug/netstandard2.0/n1.AssemblyInfo.fs"
-                  projDir / "Library.fs" ]
-                |> List.map Path.GetFullPath
+        let expectedSources =
+            [ projDir / "obj/Debug/netstandard2.0/n1.AssemblyInfo.fs"
+              projDir / "Library.fs" ]
+            |> List.map Path.GetFullPath
 
-            let blPath = projDir / "n1.binlog"
-            let blExists = File.Exists blPath
+        let blPath = projDir / "n1.binlog"
+        let blExists = File.Exists blPath
 
-            Expect.isTrue blExists "binlog file should exist"
-            Expect.equal parsed.Length 1 "console and lib"
-            Expect.equal n1Parsed n1Loaded "notificaton and parsed should be the same"
-            Expect.equal n1Parsed.SourceFiles expectedSources "check sources")
+        Expect.isTrue blExists "binlog file should exist"
+        Expect.equal parsed.Length 1 "console and lib"
+        Expect.equal n1Parsed n1Loaded "notificaton and parsed should be the same"
+        Expect.equal n1Parsed.SourceFiles expectedSources "check sources")
 
 [<AutoOpen>]
 module ExpectProjectSystemNotification =
@@ -833,23 +805,21 @@ module ExpectProjectSystemNotification =
 
         expected
         |> List.zip actual
-        |> List.iter
-            (fun (n, check) ->
-                let name, f = check
+        |> List.iter (fun (n, check) ->
+            let name, f = check
 
-                let minimal_info = getMessage n
+            let minimal_info = getMessage n
 
 
-                Expect.isTrue (f n) (sprintf "expected %s but was %s" name minimal_info))
+            Expect.isTrue (f n) (sprintf "expected %s but was %s" name minimal_info))
 
     type NotificationWatcher(controller: ProjectController, log) =
         let notifications = List<_>()
 
         do
-            controller.Notifications.Add
-                (fun arg ->
-                    notifications.Add(arg)
-                    log arg)
+            controller.Notifications.Add (fun arg ->
+                notifications.Add(arg)
+                log arg)
 
         member __.Notifications = notifications |> List.ofSeq
 
@@ -861,104 +831,98 @@ module ExpectProjectSystemNotification =
 
 let testProjectSystem toolsPath workspaceLoader workspaceFactory =
     testCase
-    |> withLog
-        (sprintf "can load sample2 with Project System - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "load_sample2_projectSystem"
-            copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir
+    |> withLog (sprintf "can load sample2 with Project System - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "load_sample2_projectSystem"
+        copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir
 
-            let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
+        let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
 
-            use controller = new ProjectSystem.ProjectController(toolsPath, workspaceFactory)
-            let watcher = watchNotifications logger controller
-            controller.LoadProject(projPath)
+        use controller = new ProjectSystem.ProjectController(toolsPath, workspaceFactory)
+        let watcher = watchNotifications logger controller
+        controller.LoadProject(projPath)
 
-            System.Threading.Thread.Sleep 3000
+        sleepABit ()
 
-            let parsed = controller.ProjectOptions |> Seq.toList |> List.map (snd)
-            let fcsPo = parsed.Head
+        let parsed = controller.ProjectOptions |> Seq.toList |> List.map (snd)
+        let fcsPo = parsed.Head
 
-            [ workspace false
-              loading "n1.fsproj"
-              loaded "n1.fsproj"
-              workspace true ]
-            |> expectNotifications (watcher.Notifications)
+        [ workspace false
+          loading "n1.fsproj"
+          loaded "n1.fsproj"
+          workspace true ]
+        |> expectNotifications (watcher.Notifications)
 
 
-            Expect.equal fcsPo.ReferencedProjects.Length ``sample2 NetSdk library``.ProjectReferences.Length "refs"
-            Expect.equal fcsPo.SourceFiles.Length 2 "files"
+        Expect.equal fcsPo.ReferencedProjects.Length ``sample2 NetSdk library``.ProjectReferences.Length "refs"
+        Expect.equal fcsPo.SourceFiles.Length 2 "files"
 
-            let fcs = createFCS ()
-            let result = fcs.ParseAndCheckProject(fcsPo) |> Async.RunSynchronously
+        let fcs = createFCS ()
+        let result = fcs.ParseAndCheckProject(fcsPo) |> Async.RunSynchronously
 
-            Expect.isEmpty result.Diagnostics (sprintf "no errors but was: %A" result.Diagnostics)
+        Expect.isEmpty result.Diagnostics (sprintf "no errors but was: %A" result.Diagnostics)
 
-            let uses = result.GetAllUsesOfAllSymbols()
+        let uses = result.GetAllUsesOfAllSymbols()
 
-            Expect.isNonEmpty uses "all symbols usages"
+        Expect.isNonEmpty uses "all symbols usages"
 
-            )
+    )
 
 let testProjectSystemOnChange toolsPath workspaceLoader workspaceFactory =
     testCase
-    |> withLog
-        (sprintf "can load sample2 with Project System, detect change on fsproj - %s" workspaceLoader)
-        (fun logger fs ->
-            let testDir = inDir fs "load_sample2_projectSystem_onChange"
-            copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir
+    |> withLog (sprintf "can load sample2 with Project System, detect change on fsproj - %s" workspaceLoader) (fun logger fs ->
+        let testDir = inDir fs "load_sample2_projectSystem_onChange"
+        copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir
 
-            let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
+        let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
 
-            dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
+        dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
-            use controller = new ProjectSystem.ProjectController(toolsPath, workspaceFactory)
-            let watcher = watchNotifications logger controller
-            controller.LoadProject(projPath)
+        use controller = new ProjectSystem.ProjectController(toolsPath, workspaceFactory)
+        let watcher = watchNotifications logger controller
+        controller.LoadProject(projPath)
 
-            System.Threading.Thread.Sleep 3000
+        sleepABit ()
 
 
-            [ workspace false
-              loading "n1.fsproj"
-              loaded "n1.fsproj"
-              workspace true ]
-            |> expectNotifications (watcher.Notifications)
+        [ workspace false
+          loading "n1.fsproj"
+          loaded "n1.fsproj"
+          workspace true ]
+        |> expectNotifications (watcher.Notifications)
 
-            fs.touch projPath
+        fs.touch projPath
 
-            System.Threading.Thread.Sleep 3000
+        sleepABit ()
 
-            [ workspace false
-              loading "n1.fsproj"
-              loaded "n1.fsproj"
-              workspace true
-              changed "n1.fsproj"
-              workspace false
-              loading "n1.fsproj"
-              loaded "n1.fsproj"
-              workspace true ]
-            |> expectNotifications (watcher.Notifications)
+        [ workspace false
+          loading "n1.fsproj"
+          loaded "n1.fsproj"
+          workspace true
+          changed "n1.fsproj"
+          workspace false
+          loading "n1.fsproj"
+          loaded "n1.fsproj"
+          workspace true ]
+        |> expectNotifications (watcher.Notifications)
 
-            )
+    )
 
 let debugTets toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     ptestCase
-    |> withLog
-        (sprintf "debug - %s" workspaceLoader)
-        (fun logger fs ->
+    |> withLog (sprintf "debug - %s" workspaceLoader) (fun logger fs ->
 
-            let projPath = @"D:\Programowanie\Projekty\Ionide\dotnet-proj-info\src\Ionide.ProjInfo.Sln\Ionide.ProjInfo.Sln.csproj"
+        let projPath = @"D:\Programowanie\Projekty\Ionide\dotnet-proj-info\src\Ionide.ProjInfo.Sln\Ionide.ProjInfo.Sln.csproj"
 
-            let loader = workspaceFactory toolsPath
+        let loader = workspaceFactory toolsPath
 
-            let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
 
-            printfn "%A" parsed
+        printfn "%A" parsed
 
-            )
+    )
 
 let tests toolsPath =
     let testSample3WorkspaceLoaderExpected =
@@ -1008,7 +972,7 @@ let tests toolsPath =
           testSample9 toolsPath "WorkspaceLoaderViaProjectGraph" WorkspaceLoaderViaProjectGraph.Create
           //Sln tests
           testLoadSln toolsPath "WorkspaceLoader" WorkspaceLoader.Create testSlnExpected
-        //   testLoadSln toolsPath "WorkspaceLoaderViaProjectGraph" WorkspaceLoaderViaProjectGraph.Create testSlnGraphExpected // Having issues on CI
+          //   testLoadSln toolsPath "WorkspaceLoaderViaProjectGraph" WorkspaceLoaderViaProjectGraph.Create testSlnGraphExpected // Having issues on CI
           testParseSln toolsPath
           //Render tests
           testRender2 toolsPath "WorkspaceLoader" WorkspaceLoader.Create
@@ -1038,10 +1002,14 @@ let tests toolsPath =
           testSample2WithBinLog toolsPath "WorkspaceLoader" WorkspaceLoader.Create
           testSample2WithBinLog toolsPath "WorkspaceLoaderViaProjectGraph" WorkspaceLoaderViaProjectGraph.Create
           test "can get runtimes" {
-              let runtimes = SdkDiscovery.runtimes (Paths.dotnetRoot.Value |> Option.defaultWith (fun _ -> failwith "unable to find dotnet binary"))
+              let runtimes =
+                  SdkDiscovery.runtimes (Paths.dotnetRoot.Value |> Option.defaultWith (fun _ -> failwith "unable to find dotnet binary"))
+
               Expect.isNonEmpty runtimes "should have found at least the currently-executing runtime"
           }
           test "can get sdks" {
-              let sdks = SdkDiscovery.sdks (Paths.dotnetRoot.Value |> Option.defaultWith (fun _ -> failwith "unable to find dotnet binary"))
+              let sdks =
+                  SdkDiscovery.sdks (Paths.dotnetRoot.Value |> Option.defaultWith (fun _ -> failwith "unable to find dotnet binary"))
+
               Expect.isNonEmpty sdks "should have found at least the currently-executing sdk"
           } ]


### PR DESCRIPTION
This should fix #123 by

* probing additional discovery mechanisms
* failing fast on the `init` call and notifying the caller what they need to do in order to become compliant.

I thought about making this return a result, but this is kinda a catastrophic failure mode - if we can't find the dotnet binary then nothing else works, either.