### PR TITLE
update vendored MSBuild libs and expose wrappers for .slnf files

### DIFF
--- a/src/Ionide.ProjInfo.ProjectSystem/Project.fs
+++ b/src/Ionide.ProjInfo.ProjectSystem/Project.fs
@@ -28,8 +28,7 @@ module internal ProjectCrackerCache =
 
         let projViewerItemsNormalized =
             projViewerItemsNormalized
-            |> List.map
-                (function
+            |> List.map (function
                 | ProjectViewerItem.Compile (p, c) -> ProjectViewerItem.Compile(fullPathNormalized p, c))
 
         { ProjectCrackerCache.Options = opts
@@ -47,7 +46,10 @@ type private ProjectPersistentCacheMessage =
 type internal ProjectPersistentCache(projectFile: string) =
     let cachePath = (Path.GetDirectoryName projectFile) </> "obj" </> "fsac.cache"
     let settings = JsonSerializerSettings()
-    do settings.MissingMemberHandling <- MissingMemberHandling.Error
+
+    do
+        settings.MissingMemberHandling <- MissingMemberHandling.Error
+        settings.ConstructorHandling <- ConstructorHandling.AllowNonPublicDefaultConstructor
 
     let agent =
         MailboxProcessor.Start
@@ -185,7 +187,8 @@ type internal Project(projectFile, onChange: string -> unit) =
             projectAssetsFile |> Path.GetDirectoryName |> Directory.CreateDirectory |> ignore
 
     ///File System Watcher for `obj` dir, at the moment only `project.assets.json` and `*.props`
-    let afsw = new FileSystemWatcher(Path = Path.GetDirectoryName projectAssetsFile, Filter = Path.GetFileName projectAssetsFile)
+    let afsw =
+        new FileSystemWatcher(Path = Path.GetDirectoryName projectAssetsFile, Filter = Path.GetFileName projectAssetsFile)
 
     do afsw.Changed.Add(fun _ -> agent.Post(Changed(File.GetLastWriteTimeUtc projectAssetsFile)))
     do afsw.Created.Add(fun _ -> agent.Post(Changed(File.GetLastWriteTimeUtc projectAssetsFile)))

--- a/src/Ionide.ProjInfo.Sln/FileUtilities.cs
+++ b/src/Ionide.ProjInfo.Sln/FileUtilities.cs
@@ -1,16 +1,689 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.IO;
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+#if !CLR2COMPATIBILITY
+using System.Collections.Concurrent;
+#else
+using Microsoft.Build.Shared.Concurrent;
+#endif
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 namespace Ionide.ProjInfo.Sln.Shared
 {
-    ///<summary>
-    /// A collection of utils for safer handling of file names and paths
-    ///</summary>
-    public static class FileUtilities
+
+    internal static class FileUtilitiesRegex
     {
+        // regular expression used to match file-specs beginning with "<drive letter>:" 
+        internal static readonly Regex DrivePattern = new Regex(@"^[A-Za-z]:");
+
+        // regular expression used to match UNC paths beginning with "\\<server>\<share>"
+        internal static readonly Regex UNCPattern = new Regex(String.Format(CultureInfo.InvariantCulture,
+            @"^[\{0}\{1}][\{0}\{1}][^\{0}\{1}]+[\{0}\{1}][^\{0}\{1}]+", Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+    }
+    /// <summary>
+    /// This class contains utility methods for file IO.
+    /// PERF\COVERAGE NOTE: Try to keep classes in 'shared' as granular as possible. All the methods in
+    /// each class get pulled into the resulting assembly.
+    /// </summary>
+    internal static partial class FileUtilities
+    {
+        // A list of possible test runners. If the program running has one of these substrings in the name, we assume
+        // this is a test harness.
+
+        // This flag, when set, indicates that we are running tests. Initially assume it's true. It also implies that
+        // the currentExecutableOverride is set to a path (that is non-null). Assume this is not initialized when we
+        // have the impossible combination of runningTests = false and currentExecutableOverride = null.
+
+        // This is the fake current executable we use in case we are running tests.
+
+        /// <summary>
+        /// The directory where MSBuild stores cache information used during the build.
+        /// </summary>
+        internal static string cacheDirectory = null;
+
+        /// <summary>
+        /// FOR UNIT TESTS ONLY
+        /// Clear out the static variable used for the cache directory so that tests that
+        /// modify it can validate their modifications.
+        /// </summary>
+        internal static void ClearCacheDirectoryPath()
+        {
+            cacheDirectory = null;
+        }
+
+        internal static readonly StringComparison PathComparison = GetIsFileSystemCaseSensitive() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+        /// <summary>
+        /// Determines whether the file system is case sensitive.
+        /// Copied from https://github.com/dotnet/runtime/blob/73ba11f3015216b39cb866d9fb7d3d25e93489f2/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs#L41-L59
+        /// </summary>
+        public static bool GetIsFileSystemCaseSensitive()
+        {
+            try
+            {
+                string pathWithUpperCase = Path.Combine(Path.GetTempPath(), "CASESENSITIVETEST" + Guid.NewGuid().ToString("N"));
+                using (new FileStream(pathWithUpperCase, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
+                {
+                    string lowerCased = pathWithUpperCase.ToLowerInvariant();
+                    return !File.Exists(lowerCased);
+                }
+            }
+            catch (Exception exc)
+            {
+                // In case something goes terribly wrong, we don't want to fail just because
+                // of a casing test, so we assume case-insensitive-but-preserving.
+                Debug.Fail("Casing test failed: " + exc);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Copied from https://github.com/dotnet/corefx/blob/056715ff70e14712419d82d51c8c50c54b9ea795/src/Common/src/System/IO/PathInternal.Windows.cs#L61
+        /// MSBuild should support the union of invalid path chars across the supported OSes, so builds can have the same behaviour crossplatform: https://github.com/dotnet/msbuild/issues/781#issuecomment-243942514
+        /// </summary>
+        internal static readonly char[] InvalidPathChars = new char[]
+        {
+            '|', '\0',
+            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
+            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
+            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
+            (char)31
+        };
+
+        /// <summary>
+        /// Copied from https://github.com/dotnet/corefx/blob/387cf98c410bdca8fd195b28cbe53af578698f94/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs#L18
+        /// MSBuild should support the union of invalid path chars across the supported OSes, so builds can have the same behaviour crossplatform: https://github.com/dotnet/msbuild/issues/781#issuecomment-243942514
+        /// </summary>
+        internal static readonly char[] InvalidFileNameChars = new char[]
+        {
+            '\"', '<', '>', '|', '\0',
+            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
+            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
+            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
+            (char)31, ':', '*', '?', '\\', '/'
+        };
+
+        internal static readonly char[] Slashes = { '/', '\\' };
+
+        internal static readonly string DirectorySeparatorString = Path.DirectorySeparatorChar.ToString();
+
+        private static readonly ConcurrentDictionary<string, bool> FileExistenceCache = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+
+        /// <summary>
+        /// Retrieves the MSBuild runtime cache directory
+        /// </summary>
+        internal static string GetCacheDirectory()
+        {
+            if (cacheDirectory == null)
+            {
+                cacheDirectory = Path.Combine(Path.GetTempPath(), String.Format(CultureInfo.CurrentUICulture, "MSBuild{0}-{1}", Process.GetCurrentProcess().Id, AppDomain.CurrentDomain.Id));
+            }
+
+            return cacheDirectory;
+        }
+
+        /// <summary>
+        /// Get the hex hash string for the string
+        /// </summary>
+        internal static string GetHexHash(string stringToHash)
+        {
+            return stringToHash.GetHashCode().ToString("X", CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Get the hash for the assemblyPaths
+        /// </summary>
+        internal static int GetPathsHash(IEnumerable<string> assemblyPaths)
+        {
+            StringBuilder builder = new StringBuilder();
+
+            foreach (string path in assemblyPaths)
+            {
+                if (path != null)
+                {
+                    string directoryPath = path.Trim();
+                    if (directoryPath.Length > 0)
+                    {
+                        DateTime lastModifiedTime = System.IO.File.GetLastWriteTimeUtc(directoryPath);
+                        builder.Append(lastModifiedTime.Ticks);
+                        builder.Append('|');
+                        builder.Append(directoryPath.ToUpperInvariant());
+                        builder.Append('|');
+                    }
+                }
+            }
+
+            return builder.ToString().GetHashCode();
+        }
+
+        /// <summary>
+        /// Clears the MSBuild runtime cache
+        /// </summary>
+        internal static void ClearCacheDirectory()
+        {
+            string cacheDirectory = GetCacheDirectory();
+
+            if (Directory.Exists(cacheDirectory))
+            {
+                DeleteDirectoryNoThrow(cacheDirectory, true);
+            }
+        }
+
+        /// <summary>
+        /// If the given path doesn't have a trailing slash then add one.
+        /// If the path is an empty string, does not modify it.
+        /// </summary>
+        /// <param name="fileSpec">The path to check.</param>
+        /// <returns>A path with a slash.</returns>
+        internal static string EnsureTrailingSlash(string fileSpec)
+        {
+            fileSpec = FixFilePath(fileSpec);
+            if (fileSpec.Length > 0 && !IsSlash(fileSpec[fileSpec.Length - 1]))
+            {
+                fileSpec += Path.DirectorySeparatorChar;
+            }
+
+            return fileSpec;
+        }
+
+        /// <summary>
+        /// Ensures the path does not have a leading or trailing slash after removing the first 'start' characters.
+        /// </summary>
+        internal static string EnsureNoLeadingOrTrailingSlash(string path, int start)
+        {
+            int stop = path.Length;
+            while (start < stop && IsSlash(path[start]))
+            {
+                start++;
+            }
+            while (start < stop && IsSlash(path[stop - 1]))
+            {
+                stop--;
+            }
+
+            return FixFilePath(path.Substring(start, stop - start));
+        }
+
+        /// <summary>
+        /// Ensures the path does not have a leading slash after removing the first 'start' characters but does end in a slash.
+        /// </summary>
+        internal static string EnsureTrailingNoLeadingSlash(string path, int start)
+        {
+            int stop = path.Length;
+            while (start < stop && IsSlash(path[start]))
+            {
+                start++;
+            }
+
+            return FixFilePath(start < stop && IsSlash(path[stop - 1]) ?
+                path.Substring(start) :
+                path.Substring(start) + Path.DirectorySeparatorChar);
+        }
+
+        /// <summary>
+        /// Ensures the path does not have a trailing slash.
+        /// </summary>
+        internal static string EnsureNoTrailingSlash(string path)
+        {
+            path = FixFilePath(path);
+            if (EndsWithSlash(path))
+            {
+                path = path.Substring(0, path.Length - 1);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Indicates if the given file-spec ends with a slash.
+        /// </summary>
+        /// <param name="fileSpec">The file spec.</param>
+        /// <returns>true, if file-spec has trailing slash</returns>
+        internal static bool EndsWithSlash(string fileSpec)
+        {
+            return (fileSpec.Length > 0)
+                ? IsSlash(fileSpec[fileSpec.Length - 1])
+                : false;
+        }
+
+        /// <summary>
+        /// Indicates if the given character is a slash.
+        /// </summary>
+        /// <param name="c"></param>
+        /// <returns>true, if slash</returns>
+        internal static bool IsSlash(char c)
+        {
+            return (c == Path.DirectorySeparatorChar) || (c == Path.AltDirectorySeparatorChar);
+        }
+
+        /// <summary>
+        /// Trims the string and removes any double quotes around it.
+        /// </summary>
+        internal static string TrimAndStripAnyQuotes(string path)
+        {
+            // Trim returns the same string if trimming isn't needed
+            path = path.Trim();
+            path = path.Trim(new char[] { '"' });
+
+            return path;
+        }
+
+        /// <summary>
+        /// Get the directory name of a rooted full path
+        /// </summary>
+        /// <param name="fullPath"></param>
+        /// <returns></returns>
+        internal static String GetDirectoryNameOfFullPath(String fullPath)
+        {
+            if (fullPath != null)
+            {
+                int i = fullPath.Length;
+                while (i > 0 && fullPath[--i] != Path.DirectorySeparatorChar && fullPath[i] != Path.AltDirectorySeparatorChar) ;
+                return FixFilePath(fullPath.Substring(0, i));
+            }
+            return null;
+        }
+
+        internal static string TruncatePathToTrailingSegments(string path, int trailingSegmentsToKeep)
+        {
+#if !CLR2COMPATIBILITY
+            ErrorUtilities.VerifyThrowInternalLength(path, nameof(path));
+            ErrorUtilities.VerifyThrow(trailingSegmentsToKeep >= 0, "trailing segments must be positive");
+
+            var segments = path.Split(Slashes, StringSplitOptions.RemoveEmptyEntries);
+
+            var headingSegmentsToRemove = Math.Max(0, segments.Length - trailingSegmentsToKeep);
+
+            return string.Join(DirectorySeparatorString, segments.Skip(headingSegmentsToRemove));
+#else
+            return path;
+#endif
+        }
+
+        internal static bool ContainsRelativePathSegments(string path)
+        {
+            for (int i = 0; i < path.Length; i++)
+            {
+                if (i + 1 < path.Length && path[i] == '.' && path[i + 1] == '.')
+                {
+                    if (RelativePathBoundsAreValid(path, i, i + 1))
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        i += 2;
+                        continue;
+                    }
+                }
+
+                if (path[i] == '.' && RelativePathBoundsAreValid(path, i, i))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+#if !CLR2COMPATIBILITY
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private static bool RelativePathBoundsAreValid(string path, int leftIndex, int rightIndex)
+        {
+            var leftBound = leftIndex - 1 >= 0
+                ? path[leftIndex - 1]
+                : (char?)null;
+
+            var rightBound = rightIndex + 1 < path.Length
+                ? path[rightIndex + 1]
+                : (char?)null;
+
+            return IsValidRelativePathBound(leftBound) && IsValidRelativePathBound(rightBound);
+        }
+
+#if !CLR2COMPATIBILITY
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private static bool IsValidRelativePathBound(char? c)
+        {
+            return c == null || IsAnySlash(c.Value);
+        }
+
+        /// <summary>
+        /// Gets the canonicalized full path of the provided path.
+        /// Guidance for use: call this on all paths accepted through public entry
+        /// points that need normalization. After that point, only verify the path
+        /// is rooted, using ErrorUtilities.VerifyThrowPathRooted.
+        /// ASSUMES INPUT IS ALREADY UNESCAPED.
+        /// </summary>
+        internal static string NormalizePath(string path)
+        {
+            ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
+            string fullPath = GetFullPath(path);
+            return FixFilePath(fullPath);
+        }
+
+        internal static string NormalizePath(string directory, string file)
+        {
+            return NormalizePath(Path.Combine(directory, file));
+        }
+
+#if !CLR2COMPATIBILITY
+        internal static string NormalizePath(params string[] paths)
+        {
+            return NormalizePath(Path.Combine(paths));
+        }
+#endif
+
+        private static string GetFullPath(string path)
+        {
+#if FEATURE_LEGACY_GETFULLPATH
+            if (NativeMethodsShared.IsWindows)
+            {
+                string uncheckedFullPath = NativeMethodsShared.GetFullPath(path);
+
+                if (IsPathTooLong(uncheckedFullPath))
+                {
+                    string message = ResourceUtilities.FormatString(AssemblyResources.GetString("Shared.PathTooLong"), path, NativeMethodsShared.MaxPath);
+                    throw new PathTooLongException(message);
+                }
+
+                // We really don't care about extensions here, but Path.HasExtension provides a great way to
+                // invoke the CLR's invalid path checks (these are independent of path length)
+                Path.HasExtension(uncheckedFullPath);
+
+                // If we detect we are a UNC path then we need to use the regular get full path in order to do the correct checks for UNC formatting
+                // and security checks for strings like \\?\GlobalRoot
+                return IsUNCPath(uncheckedFullPath) ? Path.GetFullPath(uncheckedFullPath) : uncheckedFullPath;
+            }
+#endif
+            return Path.GetFullPath(path);
+        }
+
+#if FEATURE_LEGACY_GETFULLPATH
+        private static bool IsUNCPath(string path)
+        {
+            if (!NativeMethodsShared.IsWindows || !path.StartsWith(@"\\", StringComparison.Ordinal))
+            {
+                return false;
+            }
+            bool isUNC = true;
+            for (int i = 2; i < path.Length - 1; i++)
+            {
+                if (path[i] == '\\')
+                {
+                    isUNC = false;
+                    break;
+                }
+            }
+
+            /*
+              From Path.cs in the CLR
+
+              Throw an ArgumentException for paths like \\, \\server, \\server\
+              This check can only be properly done after normalizing, so
+              \\foo\.. will be properly rejected.  Also, reject \\?\GLOBALROOT\
+              (an internal kernel path) because it provides aliases for drives.
+
+              throw new ArgumentException(Environment.GetResourceString("Arg_PathIllegalUNC"));
+
+               // Check for \\?\Globalroot, an internal mechanism to the kernel
+               // that provides aliases for drives and other undocumented stuff.
+               // The kernel team won't even describe the full set of what
+               // is available here - we don't want managed apps mucking
+               // with this for security reasons.
+            */
+            return isUNC || path.IndexOf(@"\\?\globalroot", StringComparison.OrdinalIgnoreCase) != -1;
+        }
+#endif // FEATURE_LEGACY_GETFULLPATH
+
+        internal static string FixFilePath(string path)
+        {
+            return string.IsNullOrEmpty(path) || Path.DirectorySeparatorChar == '\\' ? path : path.Replace('\\', '/');//.Replace("//", "/");
+        }
+
+#if !CLR2COMPATIBILITY
+        /// <summary>
+        /// If on Unix, convert backslashes to slashes for strings that resemble paths.
+        /// The heuristic is if something resembles paths (contains slashes) check if the
+        /// first segment exists and is a directory.
+        /// Use a native shared method to massage file path. If the file is adjusted,
+        /// that qualifies is as a path.
+        ///
+        /// @baseDirectory is just passed to LooksLikeUnixFilePath, to help with the check
+        /// </summary>
+        internal static string MaybeAdjustFilePath(string value, string baseDirectory = "")
+        {
+            var comparisonType = StringComparison.Ordinal;
+
+            // Don't bother with arrays or properties or network paths, or those that
+            // have no slashes.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || string.IsNullOrEmpty(value)
+                || value.StartsWith("$(", comparisonType) || value.StartsWith("@(", comparisonType)
+                || value.StartsWith("\\\\", comparisonType))
+            {
+                return value;
+            }
+
+            // For Unix-like systems, we may want to convert backslashes to slashes
+            Span<char> newValue = ConvertToUnixSlashes(value.ToCharArray());
+
+            // Find the part of the name we want to check, that is remove quotes, if present
+            bool shouldAdjust = newValue.IndexOf('/') != -1 && LooksLikeUnixFilePath(RemoveQuotes(newValue), baseDirectory);
+            return shouldAdjust ? newValue.ToString() : value;
+        }
+
+        /// <summary>
+        /// If on Unix, convert backslashes to slashes for strings that resemble paths.
+        /// This overload takes and returns ReadOnlyMemory of characters.
+        /// </summary>
+        internal static ReadOnlyMemory<char> MaybeAdjustFilePath(ReadOnlyMemory<char> value, string baseDirectory = "")
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || value.IsEmpty)
+            {
+                return value;
+            }
+
+            // Don't bother with arrays or properties or network paths.
+            if (value.Length >= 2)
+            {
+                var span = value.Span;
+
+                // The condition is equivalent to span.StartsWith("$(") || span.StartsWith("@(") || span.StartsWith("\\\\")
+                if ((span[1] == '(' && (span[0] == '$' || span[0] == '@')) ||
+                    (span[1] == '\\' && span[0] == '\\'))
+                {
+                    return value;
+                }
+            }
+
+            // For Unix-like systems, we may want to convert backslashes to slashes
+            Span<char> newValue = ConvertToUnixSlashes(value.ToArray());
+
+            // Find the part of the name we want to check, that is remove quotes, if present
+            bool shouldAdjust = newValue.IndexOf('/') != -1 && LooksLikeUnixFilePath(RemoveQuotes(newValue), baseDirectory);
+            return shouldAdjust ? newValue.ToString().AsMemory() : value;
+        }
+
+        private static Span<char> ConvertToUnixSlashes(Span<char> path)
+        {
+            return path.IndexOf('\\') == -1 ? path : CollapseSlashes(path);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Span<char> CollapseSlashes(Span<char> str)
+        {
+            int sliceLength = 0;
+
+            // Performs Regex.Replace(str, @"[\\/]+", "/")
+            for (int i = 0; i < str.Length; i++)
+            {
+                bool isCurSlash = IsAnySlash(str[i]);
+                bool isPrevSlash = i > 0 && IsAnySlash(str[i - 1]);
+
+                if (!isCurSlash || !isPrevSlash)
+                {
+                    str[sliceLength] = str[i] == '\\' ? '/' : str[i];
+                    sliceLength++;
+                }
+            }
+
+            return str.Slice(0, sliceLength);
+        }
+
+        private static Span<char> RemoveQuotes(Span<char> path)
+        {
+            int endId = path.Length - 1;
+            char singleQuote = '\'';
+            char doubleQuote = '\"';
+
+            bool hasQuotes = path.Length > 2
+                && ((path[0] == singleQuote && path[endId] == singleQuote)
+                || (path[0] == doubleQuote && path[endId] == doubleQuote));
+
+            return hasQuotes ? path.Slice(1, endId - 1) : path;
+        }
+#endif
+
+#if !CLR2COMPATIBILITY
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        internal static bool IsAnySlash(char c) => c == '/' || c == '\\';
+
+#if !CLR2COMPATIBILITY
+        /// <summary>
+        /// If on Unix, check if the string looks like a file path.
+        /// The heuristic is if something resembles paths (contains slashes) check if the
+        /// first segment exists and is a directory.
+        ///
+        /// If @baseDirectory is not null, then look for the first segment exists under
+        /// that
+        /// </summary>
+        internal static bool LooksLikeUnixFilePath(string value, string baseDirectory = "")
+            => LooksLikeUnixFilePath(value.AsSpan(), baseDirectory);
+
+        internal static bool LooksLikeUnixFilePath(ReadOnlySpan<char> value, string baseDirectory = "")
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return false;
+            }
+
+            // The first slash will either be at the beginning of the string or after the first directory name
+            int directoryLength = value.Slice(1).IndexOf('/') + 1;
+            bool shouldCheckDirectory = directoryLength != 0;
+
+            // Check for actual files or directories under / that get missed by the above logic
+            bool shouldCheckFileOrDirectory = !shouldCheckDirectory && value.Length > 0 && value[0] == '/';
+            ReadOnlySpan<char> directory = value.Slice(0, directoryLength);
+
+            return (shouldCheckDirectory && Directory.Exists(Path.Combine(baseDirectory, directory.ToString())))
+                || (shouldCheckFileOrDirectory && (File.Exists(value.ToString()) || Directory.Exists(value.ToString())));
+        }
+#endif
+
+        /// <summary>
+        /// Extracts the directory from the given file-spec.
+        /// </summary>
+        /// <param name="fileSpec">The filespec.</param>
+        /// <returns>directory path</returns>
+        internal static string GetDirectory(string fileSpec)
+        {
+            string directory = Path.GetDirectoryName(FixFilePath(fileSpec));
+
+            // if file-spec is a root directory e.g. c:, c:\, \, \\server\share
+            // NOTE: Path.GetDirectoryName also treats invalid UNC file-specs as root directories e.g. \\, \\server
+            if (directory == null)
+            {
+                // just use the file-spec as-is
+                directory = fileSpec;
+            }
+            else if ((directory.Length > 0) && !EndsWithSlash(directory))
+            {
+                // restore trailing slash if Path.GetDirectoryName has removed it (this happens with non-root directories)
+                directory += Path.DirectorySeparatorChar;
+            }
+
+            return directory;
+        }
+
+        /// <summary>
+        /// Determines whether the given assembly file name has one of the listed extensions.
+        /// </summary>
+        /// <param name="fileName">The name of the file</param>
+        /// <param name="allowedExtensions">Array of extensions to consider.</param>
+        /// <returns></returns>
+        internal static bool HasExtension(string fileName, string[] allowedExtensions)
+        {
+            Debug.Assert(allowedExtensions?.Length > 0);
+
+            // Easiest way to invoke invalid path chars
+            // check, which callers are relying on.
+            if (Path.HasExtension(fileName))
+            {
+                foreach (string extension in allowedExtensions)
+                {
+                    Debug.Assert(!String.IsNullOrEmpty(extension) && extension[0] == '.');
+
+                    if (fileName.EndsWith(extension, PathComparison))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        // ISO 8601 Universal time with sortable format
+        internal const string FileTimeFormat = "yyyy'-'MM'-'dd HH':'mm':'ss'.'fffffff";
+
+        /// <summary>
+        /// Get the currently executing assembly path
+        /// </summary>
+        internal static string ExecutingAssemblyPath => Path.GetFullPath(Assembly.GetAssembly(typeof(FileUtilities)).Location);
+
+        /// <summary>
+        /// Determines the full path for the given file-spec.
+        /// ASSUMES INPUT IS STILL ESCAPED
+        /// </summary>
+        /// <param name="fileSpec">The file spec to get the full path of.</param>
+        /// <param name="currentDirectory"></param>
+        /// <returns>full path</returns>
+        internal static string GetFullPath(string fileSpec, string currentDirectory)
+        {
+            // Sending data out of the engine into the filesystem, so time to unescape.
+            fileSpec = FixFilePath(EscapingUtilities.UnescapeAll(fileSpec));
+
+            // Data coming back from the filesystem into the engine, so time to escape it back.
+            string fullPath = EscapingUtilities.Escape(NormalizePath(Path.Combine(currentDirectory, fileSpec)));
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !EndsWithSlash(fullPath))
+            {
+                if (FileUtilitiesRegex.DrivePattern.IsMatch(fileSpec) ||
+                    FileUtilitiesRegex.UNCPattern.IsMatch(fullPath))
+                {
+                    // append trailing slash if Path.GetFullPath failed to (this happens with drive-specs and UNC shares)
+                    fullPath += Path.DirectorySeparatorChar;
+                }
+            }
+
+            return fullPath;
+        }
+
         /// <summary>
         /// A variation of Path.GetFullPath that will return the input value
         /// instead of throwing any IO exception.
@@ -30,14 +703,47 @@ namespace Ionide.ProjInfo.Sln.Shared
             return path;
         }
 
-        internal static string NormalizePath(string path)
+        /// <summary>
+        /// Compare if two paths, relative to the given currentDirectory are equal.
+        /// Does not throw IO exceptions. See <see cref="GetFullPathNoThrow(string)"/>
+        /// </summary>
+        /// <param name="first"></param>
+        /// <param name="second"></param>
+        /// <param name="currentDirectory"></param>
+        /// <param name="alwaysIgnoreCase"></param>
+        /// <returns></returns>
+        internal static bool ComparePathsNoThrow(string first, string second, string currentDirectory, bool alwaysIgnoreCase = false)
         {
-            return FixFilePath(Path.GetFullPath(path));
+            StringComparison pathComparison = alwaysIgnoreCase ? StringComparison.OrdinalIgnoreCase : PathComparison;
+            // perf: try comparing the bare strings first
+            if (string.Equals(first, second, pathComparison))
+            {
+                return true;
+            }
+
+            var firstFullPath = NormalizePathForComparisonNoThrow(first, currentDirectory);
+            var secondFullPath = NormalizePathForComparisonNoThrow(second, currentDirectory);
+
+            return string.Equals(firstFullPath, secondFullPath, pathComparison);
         }
 
-        internal static string FixFilePath(string path)
+        /// <summary>
+        /// Normalizes a path for path comparison
+        /// Does not throw IO exceptions. See <see cref="GetFullPathNoThrow(string)"/>
+        ///
+        /// </summary>
+        internal static string NormalizePathForComparisonNoThrow(string path, string currentDirectory)
         {
-            return string.IsNullOrEmpty(path) || Path.DirectorySeparatorChar == '\\' ? path : path.Replace('\\', '/');//.Replace("//", "/");
+            // file is invalid, return early to avoid triggering an exception
+            if (PathIsInvalid(path))
+            {
+                return path;
+            }
+
+            var normalizedPath = path.NormalizeForPathComparison();
+            var fullPath = GetFullPathNoThrow(Path.Combine(currentDirectory, normalizedPath));
+
+            return fullPath;
         }
 
         internal static bool PathIsInvalid(string path)
@@ -47,42 +753,677 @@ namespace Ionide.ProjInfo.Sln.Shared
                 return true;
             }
 
-            var filename = GetFileName(path);
-
-            return filename.IndexOfAny(InvalidFileNameChars) >= 0;
-        }
-
-        #region Used by top methods
-
-        internal static readonly char[] InvalidPathChars = new char[]
-        {
-            '|', '\0',
-            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
-            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
-            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
-            (char)31
-        };
-
-        internal static readonly char[] InvalidFileNameChars = new char[]
-        {
-            '\"', '<', '>', '|', '\0',
-            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
-            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
-            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
-            (char)31, ':', '*', '?', '\\', '/'
-        };
-
-        // Path.GetFileName does not react well to malformed filenames.
-        // For example, Path.GetFileName("a/b/foo:bar") returns bar instead of foo:bar
-        // It also throws exceptions on illegal path characters
-        private static string GetFileName(string path)
-        {
+            // Path.GetFileName does not react well to malformed filenames.
+            // For example, Path.GetFileName("a/b/foo:bar") returns bar instead of foo:bar
+            // It also throws exceptions on illegal path characters
             var lastDirectorySeparator = path.LastIndexOfAny(Slashes);
-            return lastDirectorySeparator >= 0 ? path.Substring(lastDirectorySeparator + 1) : path;
+
+            return path.IndexOfAny(InvalidFileNameChars, lastDirectorySeparator >= 0 ? lastDirectorySeparator + 1 : 0) >= 0;
         }
 
-        private static readonly char[] Slashes = { '/', '\\' };
+        /// <summary>
+        /// A variation on File.Delete that will throw ExceptionHandling.NotExpectedException exceptions
+        /// </summary>
+        internal static void DeleteNoThrow(string path)
+        {
+            try
+            {
+                File.Delete(FixFilePath(path));
+            }
+            catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
+            {
+            }
+        }
 
-        #endregion
+        /// <summary>
+        /// A variation on Directory.Delete that will throw ExceptionHandling.NotExpectedException exceptions
+        /// </summary>
+        [SuppressMessage("Microsoft.Usage", "CA1806:DoNotIgnoreMethodResults", MessageId = "System.Int32.TryParse(System.String,System.Int32@)", Justification = "We expect the out value to be 0 if the parse fails and compensate accordingly")]
+        internal static void DeleteDirectoryNoThrow(string path, bool recursive, int retryCount = 0, int retryTimeOut = 0)
+        {
+            // Try parse will set the out parameter to 0 if the string passed in is null, or is outside the range of an int.
+            if (!int.TryParse(Environment.GetEnvironmentVariable("MSBUILDDIRECTORYDELETERETRYCOUNT"), out retryCount))
+            {
+                retryCount = 0;
+            }
+
+            if (!int.TryParse(Environment.GetEnvironmentVariable("MSBUILDDIRECTORYDELETRETRYTIMEOUT"), out retryTimeOut))
+            {
+                retryTimeOut = 0;
+            }
+
+            retryCount = retryCount < 1 ? 2 : retryCount;
+            retryTimeOut = retryTimeOut < 1 ? 500 : retryTimeOut;
+
+            path = FixFilePath(path);
+
+            for (int i = 0; i < retryCount; i++)
+            {
+                try
+                {
+                    if (Directory.Exists(path))
+                    {
+                        Directory.Delete(path, recursive);
+                        break;
+                    }
+                }
+                catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
+                {
+                }
+
+                if (i + 1 < retryCount) // should not wait for the final iteration since we not gonna check anyway
+                {
+                    Thread.Sleep(retryTimeOut);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Deletes a directory, ensuring that Directory.Delete does not get a path ending in a slash.
+        /// </summary>
+        /// <remarks>
+        /// This is a workaround for https://github.com/dotnet/corefx/issues/3780, which clashed with a common
+        /// pattern in our tests.
+        /// </remarks>
+        internal static void DeleteWithoutTrailingBackslash(string path, bool recursive = false)
+        {
+            //  Some tests (such as FileMatcher and Evaluation tests) were failing with an UnauthorizedAccessException or directory not empty.
+            //  This retry logic works around that issue.
+            const int NUM_TRIES = 3;
+            for (int i = 0; i < NUM_TRIES; i++)
+            {
+                try
+                {
+                    Directory.Delete(EnsureNoTrailingSlash(path), recursive);
+
+                    //  If we got here, the directory was successfully deleted
+                    return;
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    if (i == NUM_TRIES - 1)
+                    {
+                        //var files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories);
+                        //string fileString = string.Join(Environment.NewLine, files);
+                        //string message = $"Unable to delete directory '{path}'.  Contents:" + Environment.NewLine + fileString;
+                        //throw new IOException(message, ex);
+                        throw;
+                    }
+                }
+
+                Thread.Sleep(10);
+            }
+        }
+
+        /// <summary>
+        /// Gets a file info object for the specified file path. If the file path
+        /// is invalid, or is a directory, or cannot be accessed, or does not exist,
+        /// it returns null rather than throwing or returning a FileInfo around a non-existent file.
+        /// This allows it to be called where File.Exists() (which never throws, and returns false
+        /// for directories) was called - but with the advantage that a FileInfo object is returned
+        /// that can be queried (e.g., for LastWriteTime) without hitting the disk again.
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <returns>FileInfo around path if it is an existing /file/, else null</returns>
+        internal static FileInfo GetFileInfoNoThrow(string filePath)
+        {
+            filePath = AttemptToShortenPath(filePath);
+
+            FileInfo fileInfo;
+
+            try
+            {
+                fileInfo = new FileInfo(filePath);
+            }
+            catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
+            {
+                // Invalid or inaccessible path: treat as if nonexistent file, just as File.Exists does
+                return null;
+            }
+
+            if (fileInfo.Exists)
+            {
+                // It's an existing file
+                return fileInfo;
+            }
+            else
+            {
+                // Nonexistent, or existing but a directory, just as File.Exists behaves
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Returns if the directory exists
+        /// </summary>
+        /// <param name="fullPath">Full path to the directory in the filesystem</param>
+        /// <returns></returns>
+        internal static bool DirectoryExistsNoThrow(string fullPath)
+        {
+            fullPath = AttemptToShortenPath(fullPath);
+
+            try
+            {
+                return Directory.Exists(fullPath);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns if the directory exists
+        /// </summary>
+        /// <param name="fullPath">Full path to the file in the filesystem</param>
+        /// <returns></returns>
+        internal static bool FileExistsNoThrow(string fullPath)
+        {
+            fullPath = AttemptToShortenPath(fullPath);
+
+            try
+            {
+                return File.Exists(fullPath);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// If there is a directory or file at the specified path, returns true.
+        /// Otherwise, returns false.
+        /// Does not throw IO exceptions, to match Directory.Exists and File.Exists.
+        /// Unlike calling each of those in turn it only accesses the disk once, which is faster.
+        /// </summary>
+        internal static bool FileOrDirectoryExistsNoThrow(string fullPath)
+        {
+            fullPath = AttemptToShortenPath(fullPath);
+
+            try
+            {
+                return File.Exists(fullPath) || Directory.Exists(fullPath);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// This method returns true if the specified filename is a solution file (.sln) or
+        /// solution filter file (.slnf); otherwise, it returns false.
+        /// </summary>
+        /// <remarks>
+        /// Solution filters are included because they are a thin veneer over solutions, just
+        /// with a more limited set of projects to build, and should be treated the same way.
+        /// </remarks>
+        internal static bool IsSolutionFilename(string filename)
+        {
+            return HasExtension(filename, ".sln") || HasExtension(filename, ".slnf");
+        }
+
+        internal static bool IsSolutionFilterFilename(string filename)
+        {
+            return HasExtension(filename, ".slnf");
+        }
+
+        /// <summary>
+        /// Returns true if the specified filename is a VC++ project file, otherwise returns false
+        /// </summary>
+        internal static bool IsVCProjFilename(string filename)
+        {
+            return HasExtension(filename, ".vcproj");
+        }
+
+        internal static bool IsDspFilename(string filename)
+        {
+            return HasExtension(filename, ".dsp");
+        }
+
+        /// <summary>
+        /// Returns true if the specified filename is a metaproject file (.metaproj), otherwise false.
+        /// </summary>
+        internal static bool IsMetaprojectFilename(string filename)
+        {
+            return HasExtension(filename, ".metaproj");
+        }
+
+        internal static bool IsBinaryLogFilename(string filename)
+        {
+            return HasExtension(filename, ".binlog");
+        }
+
+        private static bool HasExtension(string filename, string extension)
+        {
+            if (String.IsNullOrEmpty(filename))
+                return false;
+
+            return filename.EndsWith(extension, PathComparison);
+        }
+
+        /// <summary>
+        /// Given the absolute location of a file, and a disc location, returns relative file path to that disk location.
+        /// Throws UriFormatException.
+        /// </summary>
+        /// <param name="basePath">
+        /// The base path we want to be relative to. Must be absolute.
+        /// Should <i>not</i> include a filename as the last segment will be interpreted as a directory.
+        /// </param>
+        /// <param name="path">
+        /// The path we need to make relative to basePath.  The path can be either absolute path or a relative path in which case it is relative to the base path.
+        /// If the path cannot be made relative to the base path (for example, it is on another drive), it is returned verbatim.
+        /// If the basePath is an empty string, returns the path.
+        /// </param>
+        /// <returns>relative path (can be the full path)</returns>
+        internal static string MakeRelative(string basePath, string path)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(basePath, nameof(basePath));
+            ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
+
+            string fullBase = Path.GetFullPath(basePath);
+            string fullPath = Path.GetFullPath(path);
+
+            string[] splitBase = fullBase.Split(MSBuildConstants.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+            string[] splitPath = fullPath.Split(MSBuildConstants.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+
+            ErrorUtilities.VerifyThrow(splitPath.Length > 0, "Cannot call MakeRelative on a path of only slashes.");
+
+            // On a mac, the path could start with any number of slashes and still be valid. We have to check them all.
+            int indexOfFirstNonSlashChar = 0;
+            while (path[indexOfFirstNonSlashChar] == Path.DirectorySeparatorChar)
+            {
+                indexOfFirstNonSlashChar++;
+            }
+            if (path.IndexOf(splitPath[0]) != indexOfFirstNonSlashChar)
+            {
+                // path was already relative so just return it
+                return FixFilePath(path);
+            }
+
+            int index = 0;
+            while (index < splitBase.Length && index < splitPath.Length && splitBase[index].Equals(splitPath[index], PathComparison))
+            {
+                index++;
+            }
+
+            if (index == splitBase.Length && index == splitPath.Length)
+            {
+                return ".";
+            }
+
+            // If the paths have no component in common, the only valid relative path is the full path.
+            if (index == 0)
+            {
+                return fullPath;
+            }
+
+            StringBuilder sb = StringBuilderCache.Acquire();
+
+            for (int i = index; i < splitBase.Length; i++)
+            {
+                sb.Append("..").Append(Path.DirectorySeparatorChar);
+            }
+            for (int i = index; i < splitPath.Length; i++)
+            {
+                sb.Append(splitPath[i]).Append(Path.DirectorySeparatorChar);
+            }
+
+            if (fullPath[fullPath.Length - 1] != Path.DirectorySeparatorChar)
+            {
+                sb.Length--;
+            }
+
+            return StringBuilderCache.GetStringAndRelease(sb);
+        }
+
+        /// <summary>
+        /// Helper function to create an Uri object from path.
+        /// </summary>
+        /// <param name="path">path string</param>
+        /// <returns>uri object</returns>
+        private static Uri CreateUriFromPath(string path)
+        {
+            ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
+
+            Uri pathUri;
+
+            // Try absolute first, then fall back on relative, otherwise it
+            // makes some absolute UNC paths like (\\foo\bar) relative ...
+            if (!Uri.TryCreate(path, UriKind.Absolute, out pathUri))
+            {
+                pathUri = new Uri(path, UriKind.Relative);
+            }
+
+            return pathUri;
+        }
+
+        /// <summary>
+        /// Normalizes the path if and only if it is longer than max path,
+        /// or would be if rooted by the current directory.
+        /// This may make it shorter by removing ".."'s.
+        /// </summary>
+        internal static string AttemptToShortenPath(string path)
+        {
+            if (IsPathTooLong(path) || IsPathTooLongIfRooted(path))
+            {
+                // Attempt to make it shorter -- perhaps there are some \..\ elements
+                path = GetFullPathNoThrow(path);
+            }
+            return FixFilePath(path);
+        }
+
+        private static bool IsPathTooLong(string path)
+        {
+            // >= not > because MAX_PATH assumes a trailing null
+            return path.Length >= NativeMethods.MaxPath;
+        }
+
+        private static bool IsPathTooLongIfRooted(string path)
+        {
+            bool hasMaxPath = NativeMethods.HasMaxPath;
+            int maxPath = NativeMethods.MaxPath;
+            // >= not > because MAX_PATH assumes a trailing null
+            return hasMaxPath && !IsRootedNoThrow(path) && NativeMethods.GetCurrentDirectory().Length + path.Length + 1 /* slash */ >= maxPath;
+        }
+
+        /// <summary>
+        /// A variation of Path.IsRooted that not throw any IO exception.
+        /// </summary>
+        private static bool IsRootedNoThrow(string path)
+        {
+            try
+            {
+                return Path.IsPathRooted(FixFilePath(path));
+            }
+            catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Get the folder N levels above the given. Will stop and return current path when rooted.
+        /// </summary>
+        /// <param name="path">Path to get the folder above.</param>
+        /// <param name="count">Number of levels up to walk.</param>
+        /// <returns>Full path to the folder N levels above the path.</returns>
+        internal static string GetFolderAbove(string path, int count = 1)
+        {
+            if (count < 1)
+                return path;
+
+            var parent = Directory.GetParent(path);
+
+            while (count > 1 && parent?.Parent != null)
+            {
+                parent = parent.Parent;
+                count--;
+            }
+
+            return parent?.FullName ?? path;
+        }
+
+        /// <summary>
+        /// Combine multiple paths. Should only be used when compiling against .NET 2.0.
+        /// <remarks>
+        /// Only use in .NET 2.0. Otherwise, use System.IO.Path.Combine(...)
+        /// </remarks>
+        /// </summary>
+        /// <param name="root">Root path.</param>
+        /// <param name="paths">Paths to concatenate.</param>
+        /// <returns>Combined path.</returns>
+        internal static string CombinePaths(string root, params string[] paths)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(root, nameof(root));
+            ErrorUtilities.VerifyThrowArgumentNull(paths, nameof(paths));
+
+            return paths.Aggregate(root, Path.Combine);
+        }
+
+        internal static string TrimTrailingSlashes(this string s)
+        {
+            return s.TrimEnd(Slashes);
+        }
+
+        /// <summary>
+        /// Replace all backward slashes to forward slashes
+        /// </summary>
+        internal static string ToSlash(this string s)
+        {
+            return s.Replace('\\', '/');
+        }
+
+        internal static string ToBackslash(this string s)
+        {
+            return s.Replace('/', '\\');
+        }
+
+        /// <summary>
+        /// Ensure all slashes are the current platform's slash
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        internal static string ToPlatformSlash(this string s)
+        {
+            var separator = Path.DirectorySeparatorChar;
+
+            return s.Replace(separator == '/' ? '\\' : '/', separator);
+        }
+
+        internal static string WithTrailingSlash(this string s)
+        {
+            return EnsureTrailingSlash(s);
+        }
+
+        internal static string NormalizeForPathComparison(this string s) => s.ToPlatformSlash().TrimTrailingSlashes();
+
+        // TODO: assumption on file system case sensitivity: https://github.com/dotnet/msbuild/issues/781
+        internal static bool PathsEqual(string path1, string path2)
+        {
+            if (path1 == null && path2 == null)
+            {
+                return true;
+            }
+            if (path1 == null || path2 == null)
+            {
+                return false;
+            }
+
+            var endA = path1.Length - 1;
+            var endB = path2.Length - 1;
+
+            // Trim trailing slashes
+            for (var i = endA; i >= 0; i--)
+            {
+                var c = path1[i];
+                if (c == '/' || c == '\\')
+                {
+                    endA--;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            for (var i = endB; i >= 0; i--)
+            {
+                var c = path2[i];
+                if (c == '/' || c == '\\')
+                {
+                    endB--;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (endA != endB)
+            {
+                // Lengths not the same
+                return false;
+            }
+
+            for (var i = 0; i <= endA; i++)
+            {
+                var charA = (uint)path1[i];
+                var charB = (uint)path2[i];
+
+                if ((charA | charB) > 0x7F)
+                {
+                    // Non-ascii chars move to non fast path
+                    return PathsEqualNonAscii(path1, path2, i, endA - i + 1);
+                }
+
+                // uppercase both chars - notice that we need just one compare per char
+                if ((uint)(charA - 'a') <= (uint)('z' - 'a')) charA -= 0x20;
+                if ((uint)(charB - 'a') <= (uint)('z' - 'a')) charB -= 0x20;
+
+                // Set path delimiters the same
+                if (charA == '\\')
+                {
+                    charA = '/';
+                }
+                if (charB == '\\')
+                {
+                    charB = '/';
+                }
+
+                if (charA != charB)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static StreamWriter OpenWrite(string path, bool append, Encoding encoding = null)
+        {
+            const int DefaultFileStreamBufferSize = 4096;
+            FileMode mode = append ? FileMode.Append : FileMode.Create;
+            Stream fileStream = new FileStream(path, mode, FileAccess.Write, FileShare.Read, DefaultFileStreamBufferSize, FileOptions.SequentialScan);
+            if (encoding == null)
+            {
+                return new StreamWriter(fileStream);
+            }
+            else
+            {
+                return new StreamWriter(fileStream, encoding);
+            }
+        }
+
+        internal static StreamReader OpenRead(string path, Encoding encoding = null, bool detectEncodingFromByteOrderMarks = true)
+        {
+            const int DefaultFileStreamBufferSize = 4096;
+            Stream fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultFileStreamBufferSize, FileOptions.SequentialScan);
+            if (encoding == null)
+            {
+                return new StreamReader(fileStream);
+            }
+            else
+            {
+                return new StreamReader(fileStream, encoding, detectEncodingFromByteOrderMarks);
+            }
+        }
+
+        /// <summary>
+        /// Locate a file in either the directory specified or a location in the
+        /// directory structure above that directory.
+        /// </summary>
+        internal static string GetDirectoryNameOfFileAbove(string startingDirectory, string fileName)
+        {
+            // Canonicalize our starting location
+            string lookInDirectory = GetFullPath(startingDirectory);
+
+            do
+            {
+                // Construct the path that we will use to test against
+                string possibleFileDirectory = Path.Combine(lookInDirectory, fileName);
+
+                // If we successfully locate the file in the directory that we're
+                // looking in, simply return that location. Otherwise we'll
+                // keep moving up the tree.
+                if (File.Exists(possibleFileDirectory))
+                {
+                    // We've found the file, return the directory we found it in
+                    return lookInDirectory;
+                }
+                else
+                {
+                    // GetDirectoryName will return null when we reach the root
+                    // terminating our search
+                    lookInDirectory = Path.GetDirectoryName(lookInDirectory);
+                }
+            }
+            while (lookInDirectory != null);
+
+            // When we didn't find the location, then return an empty string
+            return String.Empty;
+        }
+
+        /// <summary>
+        /// Searches for a file based on the specified starting directory.
+        /// </summary>
+        /// <param name="file">The file to search for.</param>
+        /// <param name="startingDirectory">An optional directory to start the search in.  The default location is the directory
+        ///     of the file containing the property function.</param>
+        /// <returns>The full path of the file if it is found, otherwise an empty string.</returns>
+        internal static string GetPathOfFileAbove(string file, string startingDirectory)
+        {
+            // This method does not accept a path, only a file name
+            if (file.Any(i => i.Equals(Path.DirectorySeparatorChar) || i.Equals(Path.AltDirectorySeparatorChar)))
+            {
+                ErrorUtilities.ThrowArgument("InvalidGetPathOfFileAboveParameter", file);
+            }
+
+            // Search for a directory that contains that file
+            string directoryName = GetDirectoryNameOfFileAbove(startingDirectory, file);
+
+            return String.IsNullOrEmpty(directoryName) ? String.Empty : NormalizePath(directoryName, file);
+        }
+
+        internal static void EnsureDirectoryExists(string directoryPath)
+        {
+            if (directoryPath != null && !Directory.Exists(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+        }
+
+        // Method is simple set of function calls and may inline;
+        // we don't want it inlining into the tight loop that calls it as an exit case,
+        // so mark as non-inlining
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static bool PathsEqualNonAscii(string strA, string strB, int i, int length)
+        {
+            if (string.Compare(strA, i, strB, i, length, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                return true;
+            }
+
+            var slash1 = strA.ToSlash();
+            var slash2 = strB.ToSlash();
+
+            if (string.Compare(slash1, i, slash2, i, length, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+#if !CLR2COMPATIBILITY
+        /// <summary>
+        /// Clears the file existence cache.
+        /// </summary>
+        internal static void ClearFileExistenceCache()
+        {
+            FileExistenceCache.Clear();
+        }
+#endif
     }
 }

--- a/src/Ionide.ProjInfo.Sln/Ionide.ProjInfo.Sln.csproj
+++ b/src/Ionide.ProjInfo.Sln/Ionide.ProjInfo.Sln.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <Description>Parse sln files</Description>
     <DefineConstants>FULL_SLN_PARSER;STANDALONEBUILD;$(DefineConstants)</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Ionide.ProjInfo.Sln/NativeMethods.cs
+++ b/src/Ionide.ProjInfo.Sln/NativeMethods.cs
@@ -1,0 +1,1677 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+using Ionide.ProjInfo.Sln.Shared;
+using Microsoft.Win32;
+using Microsoft.Win32.SafeHandles;
+
+using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
+
+namespace Ionide.ProjInfo.Sln.Shared
+{
+    internal static class NativeMethods
+    {
+        #region Constants
+
+        internal const uint ERROR_INSUFFICIENT_BUFFER = 0x8007007A;
+        internal const uint STARTUP_LOADER_SAFEMODE = 0x10;
+        internal const uint S_OK = 0x0;
+        internal const uint S_FALSE = 0x1;
+        internal const uint ERROR_ACCESS_DENIED = 0x5;
+        internal const uint ERROR_FILE_NOT_FOUND = 0x80070002;
+        internal const uint FUSION_E_PRIVATE_ASM_DISALLOWED = 0x80131044; // Tried to find unsigned assembly in GAC
+        internal const uint RUNTIME_INFO_DONT_SHOW_ERROR_DIALOG = 0x40;
+        internal const uint FILE_TYPE_CHAR = 0x0002;
+        internal const Int32 STD_OUTPUT_HANDLE = -11;
+        internal const uint RPC_S_CALLPENDING = 0x80010115;
+        internal const uint E_ABORT = (uint)0x80004004;
+
+        internal const int FILE_ATTRIBUTE_READONLY = 0x00000001;
+        internal const int FILE_ATTRIBUTE_DIRECTORY = 0x00000010;
+        internal const int FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400;
+
+        /// <summary>
+        /// Default buffer size to use when dealing with the Windows API.
+        /// </summary>
+        internal const int MAX_PATH = 260;
+
+        private const string kernel32Dll = "kernel32.dll";
+        private const string mscoreeDLL = "mscoree.dll";
+
+        private const string WINDOWS_FILE_SYSTEM_REGISTRY_KEY = @"SYSTEM\CurrentControlSet\Control\FileSystem";
+        private const string WINDOWS_LONG_PATHS_ENABLED_VALUE_NAME = "LongPathsEnabled";
+
+        internal static DateTime MinFileDate { get; } = DateTime.FromFileTimeUtc(0);
+
+#if FEATURE_HANDLEREF
+    internal static HandleRef NullHandleRef = new HandleRef(null, IntPtr.Zero);
+#endif
+
+        internal static IntPtr NullIntPtr = new IntPtr(0);
+
+        // As defined in winnt.h:
+        internal const ushort PROCESSOR_ARCHITECTURE_INTEL = 0;
+        internal const ushort PROCESSOR_ARCHITECTURE_ARM = 5;
+        internal const ushort PROCESSOR_ARCHITECTURE_IA64 = 6;
+        internal const ushort PROCESSOR_ARCHITECTURE_AMD64 = 9;
+        internal const ushort PROCESSOR_ARCHITECTURE_ARM64 = 12;
+
+        internal const uint INFINITE = 0xFFFFFFFF;
+        internal const uint WAIT_ABANDONED_0 = 0x00000080;
+        internal const uint WAIT_OBJECT_0 = 0x00000000;
+        internal const uint WAIT_TIMEOUT = 0x00000102;
+
+#if FEATURE_CHARSET_AUTO
+    internal const CharSet AutoOrUnicode = CharSet.Auto;
+#else
+        internal const CharSet AutoOrUnicode = CharSet.Unicode;
+#endif
+
+        #endregion
+
+        #region Enums
+
+        private enum PROCESSINFOCLASS : int
+        {
+            ProcessBasicInformation = 0,
+            ProcessQuotaLimits,
+            ProcessIoCounters,
+            ProcessVmCounters,
+            ProcessTimes,
+            ProcessBasePriority,
+            ProcessRaisePriority,
+            ProcessDebugPort,
+            ProcessExceptionPort,
+            ProcessAccessToken,
+            ProcessLdtInformation,
+            ProcessLdtSize,
+            ProcessDefaultHardErrorMode,
+            ProcessIoPortHandlers, // Note: this is kernel mode only
+            ProcessPooledUsageAndLimits,
+            ProcessWorkingSetWatch,
+            ProcessUserModeIOPL,
+            ProcessEnableAlignmentFaultFixup,
+            ProcessPriorityClass,
+            ProcessWx86Information,
+            ProcessHandleCount,
+            ProcessAffinityMask,
+            ProcessPriorityBoost,
+            MaxProcessInfoClass
+        };
+
+        private enum eDesiredAccess : int
+        {
+            DELETE = 0x00010000,
+            READ_CONTROL = 0x00020000,
+            WRITE_DAC = 0x00040000,
+            WRITE_OWNER = 0x00080000,
+            SYNCHRONIZE = 0x00100000,
+            STANDARD_RIGHTS_ALL = 0x001F0000,
+
+            PROCESS_TERMINATE = 0x0001,
+            PROCESS_CREATE_THREAD = 0x0002,
+            PROCESS_SET_SESSIONID = 0x0004,
+            PROCESS_VM_OPERATION = 0x0008,
+            PROCESS_VM_READ = 0x0010,
+            PROCESS_VM_WRITE = 0x0020,
+            PROCESS_DUP_HANDLE = 0x0040,
+            PROCESS_CREATE_PROCESS = 0x0080,
+            PROCESS_SET_QUOTA = 0x0100,
+            PROCESS_SET_INFORMATION = 0x0200,
+            PROCESS_QUERY_INFORMATION = 0x0400,
+            PROCESS_ALL_ACCESS = SYNCHRONIZE | 0xFFF
+        }
+#pragma warning disable 0649, 0169
+        internal enum LOGICAL_PROCESSOR_RELATIONSHIP
+        {
+            RelationProcessorCore,
+            RelationNumaNode,
+            RelationCache,
+            RelationProcessorPackage,
+            RelationGroup,
+            RelationAll = 0xffff
+        }
+        internal struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX
+        {
+            public LOGICAL_PROCESSOR_RELATIONSHIP Relationship;
+            public uint Size;
+            public PROCESSOR_RELATIONSHIP Processor;
+        }
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct PROCESSOR_RELATIONSHIP
+        {
+            public byte Flags;
+            private byte EfficiencyClass;
+            private fixed byte Reserved[20];
+            public ushort GroupCount;
+            public IntPtr GroupInfo;
+        }
+#pragma warning restore 0169, 0149
+
+        /// <summary>
+        /// Flags for CoWaitForMultipleHandles
+        /// </summary>
+        [Flags]
+        public enum COWAIT_FLAGS : int
+        {
+            /// <summary>
+            /// Exit when a handle is signaled.
+            /// </summary>
+            COWAIT_NONE = 0,
+
+            /// <summary>
+            /// Exit when all handles are signaled AND a message is received.
+            /// </summary>
+            COWAIT_WAITALL = 0x00000001,
+
+            /// <summary>
+            /// Exit when an RPC call is serviced.
+            /// </summary>
+            COWAIT_ALERTABLE = 0x00000002
+        }
+
+        /// <summary>
+        /// Processor architecture values
+        /// </summary>
+        internal enum ProcessorArchitectures
+        {
+            // Intel 32 bit
+            X86,
+
+            // AMD64 64 bit
+            X64,
+
+            // Itanium 64
+            IA64,
+
+            // ARM
+            ARM,
+
+            // ARM64
+            ARM64,
+
+            // Who knows
+            Unknown
+        }
+
+        #endregion
+
+        #region Structs
+
+        /// <summary>
+        /// Structure that contain information about the system on which we are running
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SYSTEM_INFO
+        {
+            // This is a union of a DWORD and a struct containing 2 WORDs.
+            internal ushort wProcessorArchitecture;
+            internal ushort wReserved;
+
+            internal uint dwPageSize;
+            internal IntPtr lpMinimumApplicationAddress;
+            internal IntPtr lpMaximumApplicationAddress;
+            internal IntPtr dwActiveProcessorMask;
+            internal uint dwNumberOfProcessors;
+            internal uint dwProcessorType;
+            internal uint dwAllocationGranularity;
+            internal ushort wProcessorLevel;
+            internal ushort wProcessorRevision;
+        }
+
+        /// <summary>
+        /// Wrap the intptr returned by OpenProcess in a safe handle.
+        /// </summary>
+        internal class SafeProcessHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            // Create a SafeHandle, informing the base class
+            // that this SafeHandle instance "owns" the handle,
+            // and therefore SafeHandle should call
+            // our ReleaseHandle method when the SafeHandle
+            // is no longer in use
+            private SafeProcessHandle() : base(true)
+            {
+            }
+            protected override bool ReleaseHandle()
+            {
+                return CloseHandle(handle);
+            }
+        }
+
+        /// <summary>
+        /// Contains information about the current state of both physical and virtual memory, including extended memory
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = AutoOrUnicode)]
+        internal class MemoryStatus
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="T:MemoryStatus"/> class.
+            /// </summary>
+            public MemoryStatus()
+            {
+#if (CLR2COMPATIBILITY)
+            _length = (uint)Marshal.SizeOf(typeof(MemoryStatus));
+#else
+                _length = (uint)Marshal.SizeOf<MemoryStatus>();
+#endif
+            }
+
+            /// <summary>
+            /// Size of the structure, in bytes. You must set this member before calling GlobalMemoryStatusEx.
+            /// </summary>
+            private uint _length;
+
+            /// <summary>
+            /// Number between 0 and 100 that specifies the approximate percentage of physical
+            /// memory that is in use (0 indicates no memory use and 100 indicates full memory use).
+            /// </summary>
+            public uint MemoryLoad;
+
+            /// <summary>
+            /// Total size of physical memory, in bytes.
+            /// </summary>
+            public ulong TotalPhysical;
+
+            /// <summary>
+            /// Size of physical memory available, in bytes.
+            /// </summary>
+            public ulong AvailablePhysical;
+
+            /// <summary>
+            /// Size of the committed memory limit, in bytes. This is physical memory plus the
+            /// size of the page file, minus a small overhead.
+            /// </summary>
+            public ulong TotalPageFile;
+
+            /// <summary>
+            /// Size of available memory to commit, in bytes. The limit is ullTotalPageFile.
+            /// </summary>
+            public ulong AvailablePageFile;
+
+            /// <summary>
+            /// Total size of the user mode portion of the virtual address space of the calling process, in bytes.
+            /// </summary>
+            public ulong TotalVirtual;
+
+            /// <summary>
+            /// Size of unreserved and uncommitted memory in the user mode portion of the virtual
+            /// address space of the calling process, in bytes.
+            /// </summary>
+            public ulong AvailableVirtual;
+
+            /// <summary>
+            /// Size of unreserved and uncommitted memory in the extended portion of the virtual
+            /// address space of the calling process, in bytes.
+            /// </summary>
+            public ulong AvailableExtendedVirtual;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct PROCESS_BASIC_INFORMATION
+        {
+            public uint ExitStatus;
+            public IntPtr PebBaseAddress;
+            public UIntPtr AffinityMask;
+            public int BasePriority;
+            public UIntPtr UniqueProcessId;
+            public UIntPtr InheritedFromUniqueProcessId;
+
+            public uint Size
+            {
+                get
+                {
+                    unsafe
+                    {
+                        return (uint)sizeof(PROCESS_BASIC_INFORMATION);
+                    }
+                }
+            }
+        };
+
+        /// <summary>
+        /// Contains information about a file or directory; used by GetFileAttributesEx.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct WIN32_FILE_ATTRIBUTE_DATA
+        {
+            internal int fileAttributes;
+            internal uint ftCreationTimeLow;
+            internal uint ftCreationTimeHigh;
+            internal uint ftLastAccessTimeLow;
+            internal uint ftLastAccessTimeHigh;
+            internal uint ftLastWriteTimeLow;
+            internal uint ftLastWriteTimeHigh;
+            internal uint fileSizeHigh;
+            internal uint fileSizeLow;
+        }
+
+        /// <summary>
+        /// Contains the security descriptor for an object and specifies whether
+        /// the handle retrieved by specifying this structure is inheritable.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal class SecurityAttributes
+        {
+            public SecurityAttributes()
+            {
+#if (CLR2COMPATIBILITY)
+            _nLength = (uint)Marshal.SizeOf(typeof(SecurityAttributes));
+#else
+                _nLength = (uint)Marshal.SizeOf<SecurityAttributes>();
+#endif
+            }
+
+            private uint _nLength;
+
+            public IntPtr lpSecurityDescriptor;
+
+            public bool bInheritHandle;
+        }
+
+        private class SystemInformationData
+        {
+            /// <summary>
+            /// Architecture as far as the current process is concerned.
+            /// It's x86 in wow64 (native architecture is x64 in that case).
+            /// Otherwise it's the same as the native architecture.
+            /// </summary>
+            public readonly ProcessorArchitectures ProcessorArchitectureType;
+
+            /// <summary>
+            /// Actual architecture of the system.
+            /// </summary>
+            public readonly ProcessorArchitectures ProcessorArchitectureTypeNative;
+
+            /// <summary>
+            /// Convert SYSTEM_INFO architecture values to the internal enum
+            /// </summary>
+            /// <param name="arch"></param>
+            /// <returns></returns>
+            private static ProcessorArchitectures ConvertSystemArchitecture(ushort arch)
+            {
+                return arch switch
+                {
+                    PROCESSOR_ARCHITECTURE_INTEL => ProcessorArchitectures.X86,
+                    PROCESSOR_ARCHITECTURE_AMD64 => ProcessorArchitectures.X64,
+                    PROCESSOR_ARCHITECTURE_ARM => ProcessorArchitectures.ARM,
+                    PROCESSOR_ARCHITECTURE_IA64 => ProcessorArchitectures.IA64,
+                    PROCESSOR_ARCHITECTURE_ARM64 => ProcessorArchitectures.ARM64,
+                    _ => ProcessorArchitectures.Unknown,
+                };
+            }
+
+            /// <summary>
+            /// Read system info values
+            /// </summary>
+            public SystemInformationData()
+            {
+                ProcessorArchitectureType = ProcessorArchitectures.Unknown;
+                ProcessorArchitectureTypeNative = ProcessorArchitectures.Unknown;
+
+                if (IsWindows)
+                {
+                    var systemInfo = new SYSTEM_INFO();
+
+                    GetSystemInfo(ref systemInfo);
+                    ProcessorArchitectureType = ConvertSystemArchitecture(systemInfo.wProcessorArchitecture);
+
+                    GetNativeSystemInfo(ref systemInfo);
+                    ProcessorArchitectureTypeNative = ConvertSystemArchitecture(systemInfo.wProcessorArchitecture);
+                }
+                else
+                {
+                    ProcessorArchitectures processorArchitecture = ProcessorArchitectures.Unknown;
+#if !NET35
+                    // Get the architecture from the runtime.
+                    processorArchitecture = RuntimeInformation.OSArchitecture switch
+                    {
+                        Architecture.Arm => ProcessorArchitectures.ARM,
+                        Architecture.Arm64 => ProcessorArchitectures.ARM64,
+                        Architecture.X64 => ProcessorArchitectures.X64,
+                        Architecture.X86 => ProcessorArchitectures.X86,
+                        _ => ProcessorArchitectures.Unknown,
+                    };
+#endif
+                    // Fall back to 'uname -m' to get the architecture.
+                    if (processorArchitecture == ProcessorArchitectures.Unknown)
+                    {
+                        try
+                        {
+                            // On Unix run 'uname -m' to get the architecture. It's common for Linux and Mac
+                            using (
+                                var proc =
+                                    Process.Start(
+                                        new ProcessStartInfo("uname")
+                                        {
+                                            Arguments = "-m",
+                                            UseShellExecute = false,
+                                            RedirectStandardOutput = true,
+                                            CreateNoWindow = true
+                                        }))
+                            {
+                                string arch = null;
+                                if (proc != null)
+                                {
+                                    arch = proc.StandardOutput.ReadLine();
+                                    proc.WaitForExit();
+                                }
+
+                                if (!string.IsNullOrEmpty(arch))
+                                {
+                                    if (arch.StartsWith("x86_64", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        ProcessorArchitectureType = ProcessorArchitectures.X64;
+                                    }
+                                    else if (arch.StartsWith("ia64", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        ProcessorArchitectureType = ProcessorArchitectures.IA64;
+                                    }
+                                    else if (arch.StartsWith("arm", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        ProcessorArchitectureType = ProcessorArchitectures.ARM;
+                                    }
+                                    else if (arch.StartsWith("aarch64", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        ProcessorArchitectureType = ProcessorArchitectures.ARM64;
+                                    }
+                                    else if (arch.StartsWith("i", StringComparison.OrdinalIgnoreCase)
+                                            && arch.EndsWith("86", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        ProcessorArchitectureType = ProcessorArchitectures.X86;
+                                    }
+                                }
+                            }
+                        }
+                        catch
+                        {
+                            // Best effort: fall back to Unknown
+                        }
+                    }
+
+                    ProcessorArchitectureTypeNative = ProcessorArchitectureType = processorArchitecture;
+                }
+            }
+        }
+
+        public static int GetLogicalCoreCount()
+        {
+            int numberOfCpus = Environment.ProcessorCount;
+#if !MONO
+            // .NET Core on Windows returns a core count limited to the current NUMA node
+            //     https://github.com/dotnet/runtime/issues/29686
+            // so always double-check it.
+            if (IsWindows
+#if NETFRAMEWORK
+            // .NET Framework calls Windows APIs that have a core count limit (32/64 depending on process bitness).
+            // So if we get a high core count on full framework, double-check it.
+            && (numberOfCpus >= 32)
+#endif
+            )
+            {
+                var result = GetLogicalCoreCountOnWindows();
+                if (result != -1)
+                {
+                    numberOfCpus = result;
+                }
+            }
+#endif
+
+            return numberOfCpus;
+        }
+
+        /// <summary>
+        /// Get the exact physical core count on Windows
+        /// Useful for getting the exact core count in 32 bits processes,
+        /// as Environment.ProcessorCount has a 32-core limit in that case.
+        /// https://github.com/dotnet/runtime/blob/221ad5b728f93489655df290c1ea52956ad8f51c/src/libraries/System.Runtime.Extensions/src/System/Environment.Windows.cs#L171-L210
+        /// </summary>
+        private unsafe static int GetLogicalCoreCountOnWindows()
+        {
+            uint len = 0;
+            const int ERROR_INSUFFICIENT_BUFFER = 122;
+
+            if (!GetLogicalProcessorInformationEx(LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore, IntPtr.Zero, ref len) &&
+                Marshal.GetLastWin32Error() == ERROR_INSUFFICIENT_BUFFER)
+            {
+                // Allocate that much space
+                var buffer = new byte[len];
+                fixed (byte* bufferPtr = buffer)
+                {
+                    // Call GetLogicalProcessorInformationEx with the allocated buffer
+                    if (GetLogicalProcessorInformationEx(LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore, (IntPtr)bufferPtr, ref len))
+                    {
+                        // Walk each SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX in the buffer, where the Size of each dictates how
+                        // much space it's consuming.  For each group relation, count the number of active processors in each of its group infos.
+                        int processorCount = 0;
+                        byte* ptr = bufferPtr;
+                        byte* endPtr = bufferPtr + len;
+                        while (ptr < endPtr)
+                        {
+                            var current = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)ptr;
+                            if (current->Relationship == LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore)
+                            {
+                                // Flags is 0 if the core has a single logical proc, LTP_PC_SMT if more than one
+                                // for now, assume "more than 1" == 2, as it has historically been for hyperthreading
+                                processorCount += (current->Processor.Flags == 0) ? 1 : 2;
+                            }
+                            ptr += current->Size;
+                        }
+                        return processorCount;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        #endregion
+
+        #region Member data
+
+        internal static bool HasMaxPath => MaxPath == MAX_PATH;
+
+        /// <summary>
+        /// Gets the max path limit of the current OS.
+        /// </summary>
+        internal static int MaxPath
+        {
+            get
+            {
+                if (!IsMaxPathSet)
+                {
+                    SetMaxPath();
+                }
+                return _maxPath;
+            }
+        }
+
+        /// <summary>
+        /// Cached value for MaxPath.
+        /// </summary>
+        private static int _maxPath;
+
+        private static bool IsMaxPathSet { get; set; }
+
+        private static readonly object MaxPathLock = new object();
+
+        private static void SetMaxPath()
+        {
+            lock (MaxPathLock)
+            {
+                if (!IsMaxPathSet)
+                {
+                    bool isMaxPathRestricted = IsMaxPathLegacyWindows();
+                    _maxPath = isMaxPathRestricted ? MAX_PATH : int.MaxValue;
+                    IsMaxPathSet = true;
+                }
+            }
+        }
+
+        internal static bool IsMaxPathLegacyWindows()
+        {
+            try
+            {
+                return IsWindows && !IsLongPathsEnabledRegistry();
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
+        // CA1416 warns about code that can only run on Windows, but we verified we're running on Windows before this.
+        // This is the most reasonable way to resolve this part because other ways would require ifdef'ing on NET472.
+#pragma warning disable CA1416
+        private static bool IsLongPathsEnabledRegistry()
+        {
+            return false;
+        }
+#pragma warning restore CA1416
+
+        /// <summary>
+        /// Cached value for IsUnixLike (this method is called frequently during evaluation).
+        /// </summary>
+        private static readonly bool s_isUnixLike = IsLinux || IsOSX || IsBSD;
+
+        /// <summary>
+        /// Gets a flag indicating if we are running under a Unix-like system (Mac, Linux, etc.)
+        /// </summary>
+        internal static bool IsUnixLike
+        {
+            get { return s_isUnixLike; }
+        }
+
+        /// <summary>
+        /// Gets a flag indicating if we are running under Linux
+        /// </summary>
+        internal static bool IsLinux
+        {
+#if CLR2COMPATIBILITY
+            get { return false; }
+#else
+            get { return RuntimeInformation.IsOSPlatform(OSPlatform.Linux); }
+#endif
+        }
+
+        /// <summary>
+        /// Gets a flag indicating if we are running under flavor of BSD (NetBSD, OpenBSD, FreeBSD)
+        /// </summary>
+        internal static bool IsBSD
+        {
+#if CLR2COMPATIBILITY
+            get { return false; }
+#else
+            get
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")) ||
+                       RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")) ||
+                       RuntimeInformation.IsOSPlatform(OSPlatform.Create("OPENBSD"));
+            }
+#endif
+        }
+
+        private static readonly object IsMonoLock = new object();
+
+        /// <summary>
+        /// Gets a flag indicating if we are running under MONO
+        /// </summary>
+        internal static bool IsMono
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+#if !CLR2COMPATIBILITY
+        private static bool? _isWindows;
+#endif
+
+        /// <summary>
+        /// Gets a flag indicating if we are running under some version of Windows
+        /// </summary>
+        internal static bool IsWindows
+        {
+#if CLR2COMPATIBILITY
+            get { return true; }
+#else
+            get
+            {
+                if (_isWindows == null)
+                {
+                    _isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+                }
+                return _isWindows.Value;
+            }
+#endif
+        }
+
+#if !CLR2COMPATIBILITY
+        private static bool? _isOSX;
+#endif
+
+        /// <summary>
+        /// Gets a flag indicating if we are running under Mac OSX
+        /// </summary>
+        internal static bool IsOSX
+        {
+#if CLR2COMPATIBILITY
+            get { return false; }
+#else
+            get
+            {
+                if (_isOSX == null)
+                {
+                    _isOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+                }
+                return _isOSX.Value;
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Gets a string for the current OS. This matches the OS env variable
+        /// for Windows (Windows_NT).
+        /// </summary>
+        internal static string OSName
+        {
+            get { return IsWindows ? "Windows_NT" : "Unix"; }
+        }
+
+        /// <summary>
+        /// OS name that can be used for the msbuildExtensionsPathSearchPaths element
+        /// for a toolset
+        /// </summary>
+        internal static string GetOSNameForExtensionsPath()
+        {
+            return IsOSX ? "osx" : IsUnixLike ? "unix" : "windows";
+        }
+
+        internal static bool OSUsesCaseSensitivePaths
+        {
+            get { return IsLinux; }
+        }
+
+        /// <summary>
+        /// The base directory for all framework paths in Mono
+        /// </summary>
+        private static string s_frameworkBasePath;
+
+        /// <summary>
+        /// The directory of the current framework
+        /// </summary>
+        private static string s_frameworkCurrentPath;
+
+        /// <summary>
+        /// Gets the currently running framework path
+        /// </summary>
+        internal static string FrameworkCurrentPath
+        {
+            get
+            {
+                if (s_frameworkCurrentPath == null)
+                {
+                    var baseTypeLocation = Assembly.GetAssembly(typeof(string)).Location;
+
+                    s_frameworkCurrentPath =
+                        Path.GetDirectoryName(baseTypeLocation)
+                        ?? string.Empty;
+                }
+
+                return s_frameworkCurrentPath;
+            }
+        }
+
+        /// <summary>
+        /// Gets the base directory of all Mono frameworks
+        /// </summary>
+        internal static string FrameworkBasePath
+        {
+            get
+            {
+                if (s_frameworkBasePath == null)
+                {
+                    var dir = FrameworkCurrentPath;
+                    if (dir != string.Empty)
+                    {
+                        dir = Path.GetDirectoryName(dir);
+                    }
+
+                    s_frameworkBasePath = dir ?? string.Empty;
+                }
+
+                return s_frameworkBasePath;
+            }
+        }
+
+        /// <summary>
+        /// System information, initialized when required.
+        /// </summary>
+        /// <remarks>
+        /// Initially implemented as <see cref="Lazy{SystemInformationData}"/>, but
+        /// that's .NET 4+, and this is used in MSBuildTaskHost.
+        /// </remarks>
+        private static SystemInformationData SystemInformation
+        {
+            get
+            {
+                if (!_systemInformationInitialized)
+                {
+                    lock (SystemInformationLock)
+                    {
+                        if (!_systemInformationInitialized)
+                        {
+                            _systemInformation = new SystemInformationData();
+                            _systemInformationInitialized = true;
+                        }
+                    }
+                }
+                return _systemInformation;
+            }
+        }
+
+        private static SystemInformationData _systemInformation;
+        private static bool _systemInformationInitialized;
+        private static readonly object SystemInformationLock = new object();
+
+        /// <summary>
+        /// Architecture getter
+        /// </summary>
+        internal static ProcessorArchitectures ProcessorArchitecture => SystemInformation.ProcessorArchitectureType;
+
+        /// <summary>
+        /// Native architecture getter
+        /// </summary>
+        internal static ProcessorArchitectures ProcessorArchitectureNative => SystemInformation.ProcessorArchitectureTypeNative;
+
+        #endregion
+
+        #region Wrapper methods
+
+        /// <summary>
+        /// Really truly non pumping wait.
+        /// Raw IntPtrs have to be used, because the marshaller does not support arrays of SafeHandle, only
+        /// single SafeHandles.
+        /// </summary>
+        [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+        public static extern Int32 WaitForMultipleObjects(uint handle, IntPtr[] handles, bool waitAll, uint milliseconds);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern void GetNativeSystemInfo(ref SYSTEM_INFO lpSystemInfo);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool GetLogicalProcessorInformationEx(LOGICAL_PROCESSOR_RELATIONSHIP RelationshipType, IntPtr Buffer, ref uint ReturnedLength);
+
+        /// <summary>
+        /// Get the last write time of the fullpath to a directory. If the pointed path is not a directory, or
+        /// if the directory does not exist, then false is returned and fileModifiedTimeUtc is set DateTime.MinValue.
+        /// </summary>
+        /// <param name="fullPath">Full path to the file in the filesystem</param>
+        /// <param name="fileModifiedTimeUtc">The UTC last write time for the directory</param>
+        internal static bool GetLastWriteDirectoryUtcTime(string fullPath, out DateTime fileModifiedTimeUtc)
+        {
+            // This code was copied from the reference manager, if there is a bug fix in that code, see if the same fix should also be made
+            // there
+            if (IsWindows)
+            {
+                fileModifiedTimeUtc = DateTime.MinValue;
+
+                WIN32_FILE_ATTRIBUTE_DATA data = new WIN32_FILE_ATTRIBUTE_DATA();
+                bool success = GetFileAttributesEx(fullPath, 0, ref data);
+                if (success)
+                {
+                    if ((data.fileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0)
+                    {
+                        long dt = ((long)(data.ftLastWriteTimeHigh) << 32) | ((long)data.ftLastWriteTimeLow);
+                        fileModifiedTimeUtc = DateTime.FromFileTimeUtc(dt);
+                    }
+                    else
+                    {
+                        // Path does not point to a directory
+                        success = false;
+                    }
+                }
+
+                return success;
+            }
+
+            if (Directory.Exists(fullPath))
+            {
+                fileModifiedTimeUtc = Directory.GetLastWriteTimeUtc(fullPath);
+                return true;
+            }
+            else
+            {
+                fileModifiedTimeUtc = DateTime.MinValue;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Takes the path and returns the short path
+        /// </summary>
+        internal static string GetShortFilePath(string path)
+        {
+            if (!IsWindows)
+            {
+                return path;
+            }
+
+            if (path != null)
+            {
+                int length = GetShortPathName(path, null, 0);
+                int errorCode = Marshal.GetLastWin32Error();
+
+                if (length > 0)
+                {
+                    StringBuilder fullPathBuffer = new StringBuilder(length);
+                    length = GetShortPathName(path, fullPathBuffer, length);
+                    errorCode = Marshal.GetLastWin32Error();
+
+                    if (length > 0)
+                    {
+                        string fullPath = fullPathBuffer.ToString();
+                        path = fullPath;
+                    }
+                }
+
+                if (length == 0 && errorCode != 0)
+                {
+                    ThrowExceptionForErrorCode(errorCode);
+                }
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Takes the path and returns a full path
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        internal static string GetLongFilePath(string path)
+        {
+            if (IsUnixLike)
+            {
+                return path;
+            }
+
+            if (path != null)
+            {
+                int length = GetLongPathName(path, null, 0);
+                int errorCode = Marshal.GetLastWin32Error();
+
+                if (length > 0)
+                {
+                    StringBuilder fullPathBuffer = new StringBuilder(length);
+                    length = GetLongPathName(path, fullPathBuffer, length);
+                    errorCode = Marshal.GetLastWin32Error();
+
+                    if (length > 0)
+                    {
+                        string fullPath = fullPathBuffer.ToString();
+                        path = fullPath;
+                    }
+                }
+
+                if (length == 0 && errorCode != 0)
+                {
+                    ThrowExceptionForErrorCode(errorCode);
+                }
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Retrieves the current global memory status.
+        /// </summary>
+        internal static MemoryStatus GetMemoryStatus()
+        {
+            if (IsWindows)
+            {
+                MemoryStatus status = new MemoryStatus();
+                bool returnValue = GlobalMemoryStatusEx(status);
+                if (!returnValue)
+                {
+                    return null;
+                }
+
+                return status;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Get the last write time of the fullpath to the file.
+        /// </summary>
+        /// <param name="fullPath">Full path to the file in the filesystem</param>
+        /// <returns>The last write time of the file, or DateTime.MinValue if the file does not exist.</returns>
+        /// <remarks>
+        /// This method should be accurate for regular files and symlinks, but can report incorrect data
+        /// if the file's content was modified by writing to it through a different link, unless
+        /// MSBUILDALWAYSCHECKCONTENTTIMESTAMP=1.
+        /// </remarks>
+        internal static DateTime GetLastWriteFileUtcTime(string fullPath)
+        {
+
+            return LastWriteFileUtcTime(fullPath);
+
+            DateTime LastWriteFileUtcTime(string path)
+            {
+                DateTime fileModifiedTime = DateTime.MinValue;
+
+                if (IsWindows)
+                {
+                    WIN32_FILE_ATTRIBUTE_DATA data = new WIN32_FILE_ATTRIBUTE_DATA();
+                    bool success = NativeMethods.GetFileAttributesEx(path, 0, ref data);
+
+                    if (success && (data.fileAttributes & NativeMethods.FILE_ATTRIBUTE_DIRECTORY) == 0)
+                    {
+                        long dt = ((long)(data.ftLastWriteTimeHigh) << 32) | ((long)data.ftLastWriteTimeLow);
+                        fileModifiedTime = DateTime.FromFileTimeUtc(dt);
+
+                        // If file is a symlink _and_ we're not instructed to do the wrong thing, get a more accurate timestamp.
+                        if ((data.fileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == FILE_ATTRIBUTE_REPARSE_POINT)
+                        {
+                            fileModifiedTime = GetContentLastWriteFileUtcTime(path);
+                        }
+                    }
+
+                    return fileModifiedTime;
+                }
+                else
+                {
+                    return File.Exists(path)
+                        ? File.GetLastWriteTimeUtc(path)
+                        : DateTime.MinValue;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get the last write time of the content pointed to by a file path.
+        /// </summary>
+        /// <param name="fullPath">Full path to the file in the filesystem</param>
+        /// <returns>The last write time of the file, or DateTime.MinValue if the file does not exist.</returns>
+        /// <remarks>
+        /// This is the most accurate timestamp-extraction mechanism, but it is too slow to use all the time.
+        /// See https://github.com/dotnet/msbuild/issues/2052.
+        /// </remarks>
+        private static DateTime GetContentLastWriteFileUtcTime(string fullPath)
+        {
+            DateTime fileModifiedTime = DateTime.MinValue;
+
+            using (SafeFileHandle handle =
+                CreateFile(fullPath,
+                    GENERIC_READ,
+                    FILE_SHARE_READ,
+                    IntPtr.Zero,
+                    OPEN_EXISTING,
+                    FILE_ATTRIBUTE_NORMAL, /* No FILE_FLAG_OPEN_REPARSE_POINT; read through to content */
+                    IntPtr.Zero))
+            {
+                if (!handle.IsInvalid)
+                {
+                    FILETIME ftCreationTime, ftLastAccessTime, ftLastWriteTime;
+                    if (GetFileTime(handle, out ftCreationTime, out ftLastAccessTime, out ftLastWriteTime))
+                    {
+                        long fileTime = ((long)(uint)ftLastWriteTime.dwHighDateTime) << 32 |
+                                        (long)(uint)ftLastWriteTime.dwLowDateTime;
+                        fileModifiedTime =
+                            DateTime.FromFileTimeUtc(fileTime);
+                    }
+                }
+            }
+
+            return fileModifiedTime;
+        }
+
+        /// <summary>
+        /// Did the HRESULT succeed
+        /// </summary>
+        public static bool HResultSucceeded(int hr)
+        {
+            return hr >= 0;
+        }
+
+        /// <summary>
+        /// Did the HRESULT Fail
+        /// </summary>
+        public static bool HResultFailed(int hr)
+        {
+            return hr < 0;
+        }
+
+        /// <summary>
+        /// Given an error code, converts it to an HRESULT and throws the appropriate exception.
+        /// </summary>
+        /// <param name="errorCode"></param>
+        public static void ThrowExceptionForErrorCode(int errorCode)
+        {
+            // See ndp\clr\src\bcl\system\io\__error.cs for this code as it appears in the CLR.
+
+            // Something really bad went wrong with the call
+            // translate the error into an exception
+
+            // Convert the errorcode into an HRESULT (See MakeHRFromErrorCode in Win32Native.cs in
+            // ndp\clr\src\bcl\microsoft\win32)
+            errorCode = unchecked(((int)0x80070000) | errorCode);
+
+            // Throw an exception as best we can
+            Marshal.ThrowExceptionForHR(errorCode);
+        }
+
+        /// <summary>
+        /// Kills the specified process by id and all of its children recursively.
+        /// </summary>
+        internal static void KillTree(int processIdToKill)
+        {
+            // Note that GetProcessById does *NOT* internally hold on to the process handle.
+            // Only when you create the process using the Process object
+            // does the Process object retain the original handle.
+
+            Process thisProcess;
+            try
+            {
+                thisProcess = Process.GetProcessById(processIdToKill);
+            }
+            catch (ArgumentException)
+            {
+                // The process has already died for some reason.  So shrug and assume that any child processes
+                // have all also either died or are in the process of doing so.
+                return;
+            }
+
+            try
+            {
+                DateTime myStartTime = thisProcess.StartTime;
+
+                // Grab the process handle.  We want to keep this open for the duration of the function so that
+                // it cannot be reused while we are running.
+                SafeProcessHandle hProcess = OpenProcess(eDesiredAccess.PROCESS_QUERY_INFORMATION, false, processIdToKill);
+                if (hProcess.IsInvalid)
+                {
+                    return;
+                }
+
+                try
+                {
+                    try
+                    {
+                        // Kill this process, so that no further children can be created.
+                        thisProcess.Kill();
+                    }
+                    catch (Win32Exception e)
+                    {
+                        // Access denied is potentially expected -- it happens when the process that
+                        // we're attempting to kill is already dead.  So just ignore in that case.
+                        if (e.NativeErrorCode != ERROR_ACCESS_DENIED)
+                        {
+                            throw;
+                        }
+                    }
+
+                    // Now enumerate our children.  Children of this process are any process which has this process id as its parent
+                    // and which also started after this process did.
+                    List<KeyValuePair<int, SafeProcessHandle>> children = GetChildProcessIds(processIdToKill, myStartTime);
+
+                    try
+                    {
+                        foreach (KeyValuePair<int, SafeProcessHandle> childProcessInfo in children)
+                        {
+                            KillTree(childProcessInfo.Key);
+                        }
+                    }
+                    finally
+                    {
+                        foreach (KeyValuePair<int, SafeProcessHandle> childProcessInfo in children)
+                        {
+                            childProcessInfo.Value.Dispose();
+                        }
+                    }
+                }
+                finally
+                {
+                    // Release the handle.  After this point no more children of this process exist and this process has also exited.
+                    hProcess.Dispose();
+                }
+            }
+            finally
+            {
+                thisProcess.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Returns the parent process id for the specified process.
+        /// Returns zero if it cannot be gotten for some reason.
+        /// </summary>
+        internal static int GetParentProcessId(int processId)
+        {
+            int ParentID = 0;
+#if !CLR2COMPATIBILITY
+            if (IsUnixLike)
+            {
+                string line = null;
+
+                try
+                {
+                    // /proc/<processID>/stat returns a bunch of space separated fields. Get that string
+
+                    // TODO: this was
+                    // using (var r = FileUtilities.OpenRead("/proc/" + processId + "/stat"))
+                    // and could be again when FileUtilities moves to Framework
+
+                    using var fileStream = new FileStream("/proc/" + processId + "/stat", FileMode.Open, FileAccess.Read);
+                    using StreamReader r = new(fileStream);
+
+                    line = r.ReadLine();
+                }
+                catch // Ignore errors since the process may have terminated
+                {
+                }
+
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    // One of the fields is the process name. It may contain any characters, but since it's
+                    // in parenthesis, we can finds its end by looking for the last parenthesis. After that,
+                    // there comes a space, then the second fields separated by a space is the parent id.
+                    string[] statFields = line.Substring(line.LastIndexOf(')')).Split(MSBuildConstants.SpaceChar, 4);
+                    if (statFields.Length >= 3)
+                    {
+                        ParentID = Int32.Parse(statFields[2]);
+                    }
+                }
+            }
+            else
+#endif
+            {
+                SafeProcessHandle hProcess = OpenProcess(eDesiredAccess.PROCESS_QUERY_INFORMATION, false, processId);
+
+                if (!hProcess.IsInvalid)
+                {
+                    try
+                    {
+                        // UNDONE: NtQueryInformationProcess will fail if we are not elevated and other process is. Advice is to change to use ToolHelp32 API's
+                        // For now just return zero and worst case we will not kill some children.
+                        PROCESS_BASIC_INFORMATION pbi = new PROCESS_BASIC_INFORMATION();
+                        int pSize = 0;
+
+                        if (0 == NtQueryInformationProcess(hProcess, PROCESSINFOCLASS.ProcessBasicInformation, ref pbi, pbi.Size, ref pSize))
+                        {
+                            ParentID = (int)pbi.InheritedFromUniqueProcessId;
+                        }
+                    }
+                    finally
+                    {
+                        hProcess.Dispose();
+                    }
+                }
+            }
+
+            return ParentID;
+        }
+
+        /// <summary>
+        /// Returns an array of all the immediate child processes by id.
+        /// NOTE: The IntPtr in the tuple is the handle of the child process.  CloseHandle MUST be called on this.
+        /// </summary>
+        internal static List<KeyValuePair<int, SafeProcessHandle>> GetChildProcessIds(int parentProcessId, DateTime parentStartTime)
+        {
+            List<KeyValuePair<int, SafeProcessHandle>> myChildren = new List<KeyValuePair<int, SafeProcessHandle>>();
+
+            foreach (Process possibleChildProcess in Process.GetProcesses())
+            {
+                using (possibleChildProcess)
+                {
+                    // Hold the child process handle open so that children cannot die and restart with a different parent after we've started looking at it.
+                    // This way, any handle we pass back is guaranteed to be one of our actual children.
+                    SafeProcessHandle childHandle = OpenProcess(eDesiredAccess.PROCESS_QUERY_INFORMATION, false, possibleChildProcess.Id);
+                    if (childHandle.IsInvalid)
+                    {
+                        continue;
+                    }
+
+                    bool keepHandle = false;
+                    try
+                    {
+                        if (possibleChildProcess.StartTime > parentStartTime)
+                        {
+                            int childParentProcessId = GetParentProcessId(possibleChildProcess.Id);
+                            if (childParentProcessId != 0)
+                            {
+                                if (parentProcessId == childParentProcessId)
+                                {
+                                    // Add this one
+                                    myChildren.Add(new KeyValuePair<int, SafeProcessHandle>(possibleChildProcess.Id, childHandle));
+                                    keepHandle = true;
+                                }
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        if (!keepHandle)
+                        {
+                            childHandle.Dispose();
+                        }
+                    }
+                }
+            }
+
+            return myChildren;
+        }
+
+        /// <summary>
+        /// Internal, optimized GetCurrentDirectory implementation that simply delegates to the native method
+        /// </summary>
+        /// <returns></returns>
+        internal unsafe static string GetCurrentDirectory()
+        {
+#if FEATURE_LEGACY_GETCURRENTDIRECTORY
+        if (IsWindows)
+        {
+            int bufferSize = GetCurrentDirectoryWin32(0, null);
+            char* buffer = stackalloc char[bufferSize];
+            int pathLength = GetCurrentDirectoryWin32(bufferSize, buffer);
+            return new string(buffer, startIndex: 0, length: pathLength);
+        }
+#endif
+            return Directory.GetCurrentDirectory();
+        }
+
+        private unsafe static int GetCurrentDirectoryWin32(int nBufferLength, char* lpBuffer)
+        {
+            int pathLength = GetCurrentDirectory(nBufferLength, lpBuffer);
+            VerifyThrowWin32Result(pathLength);
+            return pathLength;
+        }
+
+        internal unsafe static string GetFullPath(string path)
+        {
+            int bufferSize = GetFullPathWin32(path, 0, null, IntPtr.Zero);
+            char* buffer = stackalloc char[bufferSize];
+            int fullPathLength = GetFullPathWin32(path, bufferSize, buffer, IntPtr.Zero);
+            // Avoid creating new strings unnecessarily
+            return AreStringsEqual(buffer, fullPathLength, path) ? path : new string(buffer, startIndex: 0, length: fullPathLength);
+        }
+
+        private unsafe static int GetFullPathWin32(string target, int bufferLength, char* buffer, IntPtr mustBeZero)
+        {
+            int pathLength = GetFullPathName(target, bufferLength, buffer, mustBeZero);
+            VerifyThrowWin32Result(pathLength);
+            return pathLength;
+        }
+
+        /// <summary>
+        /// Compare an unsafe char buffer with a <see cref="System.String"/> to see if their contents are identical.
+        /// </summary>
+        /// <param name="buffer">The beginning of the char buffer.</param>
+        /// <param name="len">The length of the buffer.</param>
+        /// <param name="s">The string.</param>
+        /// <returns>True only if the contents of <paramref name="s"/> and the first <paramref name="len"/> characters in <paramref name="buffer"/> are identical.</returns>
+        private unsafe static bool AreStringsEqual(char* buffer, int len, string s)
+        {
+            if (len != s.Length)
+            {
+                return false;
+            }
+
+            foreach (char ch in s)
+            {
+                if (ch != *buffer++)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static void VerifyThrowWin32Result(int result)
+        {
+            bool isError = result == 0;
+            if (isError)
+            {
+                int code = Marshal.GetLastWin32Error();
+                ThrowExceptionForErrorCode(code);
+            }
+        }
+
+        #endregion
+
+        #region PInvoke
+
+        /// <summary>
+        /// Gets the current OEM code page which is used by console apps
+        /// (as opposed to the Windows/ANSI code page)
+        /// Basically for each ANSI code page (set in Regional settings) there's a corresponding OEM code page
+        /// that needs to be used for instance when writing to batch files
+        /// </summary>
+        [DllImport(kernel32Dll)]
+        internal static extern int GetOEMCP();
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool GetFileAttributesEx(String name, int fileInfoLevel, ref WIN32_FILE_ATTRIBUTE_DATA lpFileInformation);
+
+        [DllImport(kernel32Dll, SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern uint SearchPath
+        (
+            string path,
+            string fileName,
+            string extension,
+            int numBufferChars,
+            [Out] StringBuilder buffer,
+            int[] filePart
+        );
+
+        [DllImport("kernel32.dll", PreserveSig = true, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool FreeLibrary([In] IntPtr module);
+
+        [DllImport("kernel32.dll", PreserveSig = true, BestFitMapping = false, ThrowOnUnmappableChar = true, CharSet = CharSet.Ansi, SetLastError = true)]
+        internal static extern IntPtr GetProcAddress(IntPtr module, string procName);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, PreserveSig = true, SetLastError = true)]
+        internal static extern IntPtr LoadLibrary(string fileName);
+
+        [DllImport(mscoreeDLL, SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern uint GetRequestedRuntimeInfo(String pExe,
+                                                String pwszVersion,
+                                                String pConfigurationFile,
+                                                uint startupFlags,
+                                                uint runtimeInfoFlags,
+                                                [Out] StringBuilder pDirectory,
+                                                int dwDirectory,
+                                                out uint dwDirectoryLength,
+                                                [Out] StringBuilder pVersion,
+                                                int cchBuffer,
+                                                out uint dwlength);
+
+        /// <summary>
+        /// Gets the fully qualified filename of the currently executing .exe
+        /// </summary>
+        [DllImport(kernel32Dll, SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern int GetModuleFileName(
+#if FEATURE_HANDLEREF
+            HandleRef hModule,
+#else
+            IntPtr hModule,
+#endif
+            [Out] StringBuilder buffer, int length);
+
+        [DllImport("kernel32.dll")]
+        internal static extern IntPtr GetStdHandle(int nStdHandle);
+
+        [DllImport("kernel32.dll")]
+        internal static extern uint GetFileType(IntPtr hFile);
+
+        [SuppressMessage("Microsoft.Usage", "CA2205:UseManagedEquivalentsOfWin32Api", Justification = "Using unmanaged equivalent for performance reasons")]
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal unsafe static extern int GetCurrentDirectory(int nBufferLength, char* lpBuffer);
+
+        [SuppressMessage("Microsoft.Usage", "CA2205:UseManagedEquivalentsOfWin32Api", Justification = "Using unmanaged equivalent for performance reasons")]
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "SetCurrentDirectory")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool SetCurrentDirectoryWindows(string path);
+
+        internal static bool SetCurrentDirectory(string path)
+        {
+            if (IsWindows)
+            {
+                return SetCurrentDirectoryWindows(path);
+            }
+
+            // Make sure this does not throw
+            try
+            {
+                Directory.SetCurrentDirectory(path);
+            }
+            catch
+            {
+            }
+            return true;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static unsafe extern int GetFullPathName(string target, int bufferLength, char* buffer, IntPtr mustBeZero);
+
+        [DllImport("KERNEL32.DLL")]
+        private static extern SafeProcessHandle OpenProcess(eDesiredAccess dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, int dwProcessId);
+
+        [DllImport("NTDLL.DLL")]
+        private static extern int NtQueryInformationProcess(SafeProcessHandle hProcess, PROCESSINFOCLASS pic, ref PROCESS_BASIC_INFORMATION pbi, uint cb, ref int pSize);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("kernel32.dll", CharSet = AutoOrUnicode, SetLastError = true)]
+        private static extern bool GlobalMemoryStatusEx([In, Out] MemoryStatus lpBuffer);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, BestFitMapping = false)]
+        internal static extern int GetShortPathName(string path, [Out] StringBuilder fullpath, [In] int length);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, BestFitMapping = false)]
+        internal static extern int GetLongPathName([In] string path, [Out] StringBuilder fullpath, [In] int length);
+
+        [DllImport("kernel32.dll", CharSet = AutoOrUnicode, SetLastError = true)]
+        internal static extern bool CreatePipe(out SafeFileHandle hReadPipe, out SafeFileHandle hWritePipe, SecurityAttributes lpPipeAttributes, int nSize);
+
+        [DllImport("kernel32.dll", CharSet = AutoOrUnicode, SetLastError = true)]
+        internal static extern bool ReadFile(SafeFileHandle hFile, byte[] lpBuffer, uint nNumberOfBytesToRead, out uint lpNumberOfBytesRead, IntPtr lpOverlapped);
+
+        /// <summary>
+        /// CoWaitForMultipleHandles allows us to wait in an STA apartment and still service RPC requests from other threads.
+        /// VS needs this in order to allow the in-proc compilers to properly initialize, since they will make calls from the
+        /// build thread which the main thread (blocked on BuildSubmission.Execute) must service.
+        /// </summary>
+        [DllImport("ole32.dll")]
+        public static extern int CoWaitForMultipleHandles(COWAIT_FLAGS dwFlags, int dwTimeout, int cHandles, [MarshalAs(UnmanagedType.LPArray)] IntPtr[] pHandles, out int pdwIndex);
+
+        internal const uint GENERIC_READ = 0x80000000;
+        internal const uint FILE_SHARE_READ = 0x1;
+        internal const uint FILE_ATTRIBUTE_NORMAL = 0x80;
+        internal const uint FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;
+        internal const uint OPEN_EXISTING = 3;
+
+        [DllImport("kernel32.dll", CharSet = AutoOrUnicode, CallingConvention = CallingConvention.StdCall,
+            SetLastError = true)]
+        internal static extern SafeFileHandle CreateFile(
+            string lpFileName,
+            uint dwDesiredAccess,
+            uint dwShareMode,
+            IntPtr lpSecurityAttributes,
+            uint dwCreationDisposition,
+            uint dwFlagsAndAttributes,
+            IntPtr hTemplateFile
+            );
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool GetFileTime(
+            SafeFileHandle hFile,
+            out FILETIME lpCreationTime,
+            out FILETIME lpLastAccessTime,
+            out FILETIME lpLastWriteTime
+            );
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool CloseHandle(IntPtr hObject);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool SetThreadErrorMode(int newMode, out int oldMode);
+
+        #endregion
+
+        #region Extensions
+
+        /// <summary>
+        /// Waits while pumping APC messages.  This is important if the waiting thread is an STA thread which is potentially
+        /// servicing COM calls from other threads.
+        /// </summary>
+        [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Runtime.InteropServices.SafeHandle.DangerousGetHandle", Scope = "member", Target = "Microsoft.Build.Shared.NativeMethodsShared.#MsgWaitOne(System.Threading.WaitHandle,System.Int32)", Justification = "This is necessary and it has been used for a long time. No need to change it now.")]
+        internal static bool MsgWaitOne(this WaitHandle handle)
+        {
+            return handle.MsgWaitOne(Timeout.Infinite);
+        }
+
+        /// <summary>
+        /// Waits while pumping APC messages.  This is important if the waiting thread is an STA thread which is potentially
+        /// servicing COM calls from other threads.
+        /// </summary>
+        internal static bool MsgWaitOne(this WaitHandle handle, TimeSpan timeout)
+        {
+            return MsgWaitOne(handle, (int)timeout.TotalMilliseconds);
+        }
+
+        /// <summary>
+        /// Waits while pumping APC messages.  This is important if the waiting thread is an STA thread which is potentially
+        /// servicing COM calls from other threads.
+        /// </summary>
+        [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Runtime.InteropServices.SafeHandle.DangerousGetHandle", Justification = "Necessary to avoid pumping")]
+        internal static bool MsgWaitOne(this WaitHandle handle, int timeout)
+        {
+            // CoWaitForMultipleHandles allows us to wait in an STA apartment and still service RPC requests from other threads.
+            // VS needs this in order to allow the in-proc compilers to properly initialize, since they will make calls from the
+            // build thread which the main thread (blocked on BuildSubmission.Execute) must service.
+            int waitIndex;
+#if FEATURE_HANDLE_SAFEWAITHANDLE
+        IntPtr handlePtr = handle.SafeWaitHandle.DangerousGetHandle();
+#else
+            IntPtr handlePtr = handle.GetSafeWaitHandle().DangerousGetHandle();
+#endif
+            int returnValue = CoWaitForMultipleHandles(COWAIT_FLAGS.COWAIT_NONE, timeout, 1, new IntPtr[] { handlePtr }, out waitIndex);
+
+            if (!(returnValue == 0 || ((uint)returnValue == RPC_S_CALLPENDING && timeout != Timeout.Infinite)))
+            {
+                throw new InternalErrorException($"Received {returnValue} from CoWaitForMultipleHandles, but expected 0 (S_OK)");
+            }
+
+            return returnValue == 0;
+        }
+
+        #endregion
+
+        #region helper methods
+
+        internal static bool DirectoryExists(string fullPath)
+        {
+            return IsWindows
+                ? DirectoryExistsWindows(fullPath)
+                : Directory.Exists(fullPath);
+        }
+
+        internal static bool DirectoryExistsWindows(string fullPath)
+        {
+            WIN32_FILE_ATTRIBUTE_DATA data = new WIN32_FILE_ATTRIBUTE_DATA();
+            bool success = GetFileAttributesEx(fullPath, 0, ref data);
+            return success && (data.fileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+        }
+
+        internal static bool FileExists(string fullPath)
+        {
+            return IsWindows
+                ? FileExistsWindows(fullPath)
+                : File.Exists(fullPath);
+        }
+
+        internal static bool FileExistsWindows(string fullPath)
+        {
+            WIN32_FILE_ATTRIBUTE_DATA data = new WIN32_FILE_ATTRIBUTE_DATA();
+            bool success = GetFileAttributesEx(fullPath, 0, ref data);
+            return success && (data.fileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0;
+        }
+
+        internal static bool FileOrDirectoryExists(string path)
+        {
+            return IsWindows
+                ? FileOrDirectoryExistsWindows(path)
+                : File.Exists(path) || Directory.Exists(path);
+        }
+
+        internal static bool FileOrDirectoryExistsWindows(string path)
+        {
+            WIN32_FILE_ATTRIBUTE_DATA data = new WIN32_FILE_ATTRIBUTE_DATA();
+            return GetFileAttributesEx(path, 0, ref data);
+        }
+
+        #endregion
+
+    }
+}

--- a/src/Ionide.ProjInfo.Sln/vendor/Constants.cs
+++ b/src/Ionide.ProjInfo.Sln/vendor/Constants.cs
@@ -96,6 +96,10 @@ namespace Ionide.ProjInfo.Sln.Shared
 #endif
             }
         }
+
+        internal static readonly char[] DirectorySeparatorChar = { System.IO.Path.DirectorySeparatorChar };
+
+        internal static readonly char[] SpaceChar = { ' ' };
     }
 
     /// <summary>

--- a/src/Ionide.ProjInfo.Sln/vendor/ProjectConfigurationInSolution.cs
+++ b/src/Ionide.ProjInfo.Sln/vendor/ProjectConfigurationInSolution.cs
@@ -1,9 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//-----------------------------------------------------------------------
-// </copyright>
-// <summary>Represents a project configuration (e.g. "Debug|x86")</summary>
-//-----------------------------------------------------------------------
 
 using System;
 
@@ -15,79 +11,47 @@ namespace Ionide.ProjInfo.Sln.Construction
     public sealed class ProjectConfigurationInSolution
     {
         /// <summary>
-        /// The configuration part of this configuration - e.g. "Debug", "Release"
-        /// </summary>
-        private string _configurationName;
-
-        /// <summary>
-        /// The platform part of this configuration - e.g. "Any CPU", "Win32"
-        /// </summary>
-        private string _platformName;
-
-        /// <summary>
-        /// The full name of this configuration - e.g. "Debug|Any CPU"
-        /// </summary>
-        private string _fullName;
-
-        /// <summary>
-        /// True if this project configuration should be built as part of its parent solution configuration
-        /// </summary>
-        private bool _includeInBuild;
-
-        /// <summary>
         /// Constructor
         /// </summary>
         internal ProjectConfigurationInSolution(string configurationName, string platformName, bool includeInBuild)
         {
-            _configurationName = configurationName;
-            _platformName = RemoveSpaceFromAnyCpuPlatform(platformName);
-            _includeInBuild = includeInBuild;
-            _fullName = SolutionConfigurationInSolution.ComputeFullName(_configurationName, _platformName);
+            ConfigurationName = configurationName;
+            PlatformName = RemoveSpaceFromAnyCpuPlatform(platformName);
+            IncludeInBuild = includeInBuild;
+            FullName = SolutionConfigurationInSolution.ComputeFullName(ConfigurationName, PlatformName);
         }
 
         /// <summary>
         /// The configuration part of this configuration - e.g. "Debug", "Release"
         /// </summary>
-        public string ConfigurationName
-        {
-            get { return _configurationName; }
-        }
+        public string ConfigurationName { get; }
 
         /// <summary>
         /// The platform part of this configuration - e.g. "Any CPU", "Win32"
         /// </summary>
-        public string PlatformName
-        {
-            get { return _platformName; }
-        }
+        public string PlatformName { get; }
 
         /// <summary>
         /// The full name of this configuration - e.g. "Debug|Any CPU"
         /// </summary>
-        public string FullName
-        {
-            get { return _fullName; }
-        }
+        public string FullName { get; }
 
         /// <summary>
         /// True if this project configuration should be built as part of its parent solution configuration
         /// </summary>
-        public bool IncludeInBuild
-        {
-            get { return _includeInBuild; }
-        }
+        public bool IncludeInBuild { get; }
 
         /// <summary>
         /// This is a hacky method to remove the space in the "Any CPU" platform in project configurations.
         /// The problem is that this platform is stored as "AnyCPU" in project files, but the project system
         /// reports it as "Any CPU" to the solution configuration manager. Because of that all solution configurations
-        /// contain the version with a space in it, and when we try and give that name to actual projects,
+        /// contain the version with a space in it, and when we try and give that name to actual projects, 
         /// they have no clue what we're talking about. We need to remove the space in project platforms so that
         /// the platform name matches the one used in projects.
         /// </summary>
-        static private string RemoveSpaceFromAnyCpuPlatform(string platformName)
+        private static string RemoveSpaceFromAnyCpuPlatform(string platformName)
         {
-            if (string.Compare(platformName, "Any CPU", StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Equals(platformName, "Any CPU", StringComparison.OrdinalIgnoreCase))
             {
                 return "AnyCPU";
             }

--- a/src/Ionide.ProjInfo.Sln/vendor/SolutionConfigurationInSolution.cs
+++ b/src/Ionide.ProjInfo.Sln/vendor/SolutionConfigurationInSolution.cs
@@ -1,12 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//-----------------------------------------------------------------------
-// </copyright>
-// <summary>Represents a solution configuration (e.g. "Debug|x86")</summary>
-//-----------------------------------------------------------------------
-
-using System;
-using System.Globalization;
 
 namespace Ionide.ProjInfo.Sln.Construction
 {
@@ -21,70 +14,45 @@ namespace Ionide.ProjInfo.Sln.Construction
         /// </summary>
         internal const char ConfigurationPlatformSeparator = '|';
 
-        /// <summary>
-        /// The configuration part of this configuration - e.g. "Debug", "Release"
-        /// </summary>
-        private string _configurationName;
-
-        /// <summary>
-        /// The platform part of this configuration - e.g. "Any CPU", "Win32"
-        /// </summary>
-        private string _platformName;
-
-        /// <summary>
-        /// The full name of this configuration - e.g. "Debug|Any CPU"
-        /// </summary>
-        private string _fullName;
+        internal static readonly char[] ConfigurationPlatformSeparatorArray = { '|' };
 
         /// <summary>
         /// Constructor
         /// </summary>
         internal SolutionConfigurationInSolution(string configurationName, string platformName)
         {
-            _configurationName = configurationName;
-            _platformName = platformName;
-            _fullName = ComputeFullName(configurationName, platformName);
+            ConfigurationName = configurationName;
+            PlatformName = platformName;
+            FullName = ComputeFullName(configurationName, platformName);
         }
 
         /// <summary>
         /// The configuration part of this configuration - e.g. "Debug", "Release"
         /// </summary>
-        public string ConfigurationName
-        {
-            get { return _configurationName; }
-        }
+        public string ConfigurationName { get; }
 
         /// <summary>
         /// The platform part of this configuration - e.g. "Any CPU", "Win32"
         /// </summary>
-        public string PlatformName
-        {
-            get { return _platformName; }
-        }
+        public string PlatformName { get; }
 
         /// <summary>
         /// The full name of this configuration - e.g. "Debug|Any CPU"
         /// </summary>
-        public string FullName
-        {
-            get { return _fullName; }
-        }
+        public string FullName { get; }
 
         /// <summary>
-        /// Given a configuration name and a platform name, compute the full name
+        /// Given a configuration name and a platform name, compute the full name 
         /// of this configuration
         /// </summary>
         internal static string ComputeFullName(string configurationName, string platformName)
         {
             // Some configurations don't have the platform part
-            if ((platformName != null) && (platformName.Length > 0))
+            if (!string.IsNullOrEmpty(platformName))
             {
-                return String.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", configurationName, ConfigurationPlatformSeparator, platformName);
+                return $"{configurationName}{ConfigurationPlatformSeparator}{platformName}";
             }
-            else
-            {
-                return configurationName;
-            }
+            return configurationName;
         }
     }
 }

--- a/src/Ionide.ProjInfo/InspectSln.fs
+++ b/src/Ionide.ProjInfo/InspectSln.fs
@@ -43,9 +43,10 @@ module InspectSln =
 
             let makeAbsoluteFromSlnDir =
                 let makeAbs (path: string) =
-                    if Path.IsPathRooted path
-                    then path
-                    else Path.Combine(slnDir, path) |> Path.GetFullPath
+                    if Path.IsPathRooted path then
+                        path
+                    else
+                        Path.Combine(slnDir, path) |> Path.GetFullPath
 
                 normalizeDirSeparators >> makeAbs
 
@@ -54,7 +55,9 @@ module InspectSln =
                     match item.ProjectType with
                     | Sln.Construction.SolutionProjectType.KnownToBeMSBuildFormat -> (item.RelativePath |> makeAbsoluteFromSlnDir), SolutionItemKind.MsbuildFormat []
                     | Sln.Construction.SolutionProjectType.SolutionFolder ->
-                        let children = sln.ProjectsInOrder |> Seq.filter (fun x -> x.ParentProjectGuid = item.ProjectGuid) |> Seq.map parseItem |> List.ofSeq
+                        let children =
+                            sln.ProjectsInOrder |> Seq.filter (fun x -> x.ParentProjectGuid = item.ProjectGuid) |> Seq.map parseItem |> List.ofSeq
+
                         let files = item.FolderFiles |> Seq.map makeAbsoluteFromSlnDir |> List.ofSeq
                         item.ProjectName, SolutionItemKind.Folder(children, files)
                     | Sln.Construction.SolutionProjectType.EtpSubProject
@@ -75,11 +78,12 @@ module InspectSln =
                 { Items = items |> List.ofSeq
                   Configurations = [] }
 
-            (slnFilePath, data)
+            data
 
         try
-            slnFilePath |> Sln.Construction.SolutionFile.Parse |> parseSln |> Ok
-        with ex -> Error ex
+            Ok(slnFilePath, slnFilePath |> Sln.Construction.SolutionFile.Parse |> parseSln)
+        with
+        | ex -> Error ex
 
     let loadingBuildOrder (data: SolutionData) =
 


### PR DESCRIPTION
This updates the vendored msbuild libraries and removes some unused shims, keeping the solution files support that doesn't exist upstream.