### PR TITLE
Support loading legacy .NET framework proj files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
           dotnet-version: ${{ matrix.dotnet }}
       - name: Restore tools
         run: dotnet tool restore
+      - name: Install latest F# from mono (.net 4.x)
+        if: runner.os == 'Linux'
+        run: ./install_mono_from_microsoft_deb_packages.sh
       - name: Run build
         run: dotnet fake build -t Pack
       - name: Upload NuGet packages

--- a/install_mono_from_microsoft_deb_packages.sh
+++ b/install_mono_from_microsoft_deb_packages.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+source /etc/os-release
+
+# required by apt-key
+sudo apt install -y gnupg2
+# required by apt-update when pulling from mono-project.com
+sudo apt install -y ca-certificates
+
+# taken from http://www.mono-project.com/download/stable/#download-lin
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+sudo echo "deb https://download.mono-project.com/repo/ubuntu stable-$UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+sudo apt update
+sudo apt install -y fsharp

--- a/test/Ionide.ProjInfo.Tests/Ionide.ProjInfo.Tests.fsproj
+++ b/test/Ionide.ProjInfo.Tests/Ionide.ProjInfo.Tests.fsproj
@@ -12,6 +12,9 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="16.10.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Ionide.ProjInfo\Ionide.ProjInfo.fsproj" />
     <ProjectReference Include="..\..\src\Ionide.ProjInfo.FCS\Ionide.ProjInfo.FCS.fsproj" />
     <ProjectReference Include="..\..\src\Ionide.ProjInfo.ProjectSystem\Ionide.ProjInfo.ProjectSystem.fsproj" />

--- a/test/Ionide.ProjInfo.Tests/TestAssets.fs
+++ b/test/Ionide.ProjInfo.Tests/TestAssets.fs
@@ -134,7 +134,7 @@ let ``sample6 Netsdk Sparse/sln`` =
 /// reference:
 /// - net461 lib Project1A (F#)
 /// - net461 lib Project1B (F#)
-let ``sample7 Oldsdk projs`` =
+let ``sample7 legacy framework multi-project`` =
   { ProjDir = "sample7-oldsdk-projs"
     AssemblyName = "MultiProject1"
     ProjectFile = "m1"/"MultiProject1.fsproj"
@@ -157,6 +157,18 @@ let ``sample7 Oldsdk projs`` =
           ]
           ProjectReferences = [] }
       ] }
+
+/// legacy framework net461 console project
+/// reference:
+/// - net461 lib Project1A (F#)
+let ``sample7 legacy framework project`` =
+    { ProjDir = "sample7-oldsdk-projs"
+      AssemblyName = "Project1A"
+      ProjectFile = "a"/"Project1A.fsproj"
+      TargetFrameworks =  Map.ofList [
+        "net45", sourceFiles ["Project1A.fs"]
+      ]
+      ProjectReferences = [] }
 
 /// dotnet sdk, one netstandard2.0 lib n1 with advanced solution explorer configurations
 let ``sample8 NetSdk Explorer`` =


### PR DESCRIPTION
This will open the doors to fixing this FSharpLint's bug:
https://github.com/fsprojects/FSharpLint/issues/336

(which is important for our FSharpLint v1.0 release milestone)