### PR TITLE
Only load referenced project when it is not part of the cache.

### DIFF
--- a/src/Ionide.ProjInfo/Library.fs
+++ b/src/Ionide.ProjInfo/Library.fs
@@ -916,7 +916,10 @@ type WorkspaceLoader private (toolsPath: ToolsPath, ?globalProperties: (string *
                 | Ok project ->
                     try
                         cache.Add(p, project)
-                        let lst = project.ReferencedProjects |> Seq.map (fun n -> n.ProjectFileName) |> Seq.toList
+                        let lst =
+                            project.ReferencedProjects
+                            |> Seq.choose (fun n -> if cache.ContainsKey n.ProjectFileName then None else Some n.ProjectFileName)
+                            |> Seq.toList
                         let info = Some project
                         lst, info
                     with
@@ -943,7 +946,10 @@ type WorkspaceLoader private (toolsPath: ToolsPath, ?globalProperties: (string *
                         if cache.ContainsKey p then
                             let project = cache.[p]
                             loadingNotification.Trigger(WorkspaceProjectState.Loaded(project, getAllKnown (), true)) //TODO: Should it even notify here?
-                            let lst = project.ReferencedProjects |> Seq.map (fun n -> n.ProjectFileName) |> Seq.toList
+                            let lst =
+                                project.ReferencedProjects
+                                |> Seq.choose (fun n -> if cache.ContainsKey n.ProjectFileName then None else Some n.ProjectFileName)
+                                |> Seq.toList
                             lst, None
                         else
                             loadingNotification.Trigger(WorkspaceProjectState.Loading p)


### PR DESCRIPTION
I don't think the referenced projects need to be reloaded for each project.
If they are part of the cache already, it should be fine I think.
Let me know if this makes sense.