### PR TITLE
use correct timestamp and file stream for cross-language references

### DIFF
--- a/test/examples/sample-referenced-csharp-project/csharp-lib/Class1.cs
+++ b/test/examples/sample-referenced-csharp-project/csharp-lib/Class1.cs
@@ -1,0 +1,8 @@
+﻿namespace csharp_lib;
+public class Class1
+{
+    public static string GetString()
+    {
+        return "Hello, World!";
+    }
+}

--- a/test/examples/sample-referenced-csharp-project/csharp-lib/csharp-lib.csproj
+++ b/test/examples/sample-referenced-csharp-project/csharp-lib/csharp-lib.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>csharp_lib</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Warn>$(Warn);7</Warn>
+  </PropertyGroup>
+
+</Project>

--- a/test/examples/sample-referenced-csharp-project/fsharp-exe/Program.fs
+++ b/test/examples/sample-referenced-csharp-project/fsharp-exe/Program.fs
@@ -1,0 +1,2 @@
+﻿// For more information see https://aka.ms/fsharp-console-apps
+printfn $"{csharp_lib.Class1.GetString()}"

--- a/test/examples/sample-referenced-csharp-project/fsharp-exe/fsharp-exe.fsproj
+++ b/test/examples/sample-referenced-csharp-project/fsharp-exe/fsharp-exe.fsproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>fsharp_exe</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\csharp-lib\csharp-lib.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
We should provide file timestamps and file content streams for PE references so that the compiler doesn't get _too_ hungry