### PR TITLE
add a way to efficiently map many project options to FCS options at once

### DIFF
--- a/src/Ionide.ProjInfo.FCS/Library.fs
+++ b/src/Ionide.ProjInfo.FCS/Library.fs
@@ -18,32 +18,57 @@ module FCS =
 
         FSharpReferencedProject.CreatePortableExecutable(p.TargetPath, getStamp, getStream)
 
-    let rec mapToFSharpProjectOptions (projectOptions: ProjectOptions) (allKnownProjects: ProjectOptions seq) : FSharpProjectOptions =
+    let private makeFCSOptions mapProjectToReference (project: ProjectOptions) =
         { ProjectId = None
-          ProjectFileName = projectOptions.ProjectFileName
-          SourceFiles = List.toArray projectOptions.SourceFiles
-          OtherOptions = List.toArray projectOptions.OtherOptions
-          ReferencedProjects =
-            projectOptions.ReferencedProjects
-            |> List.toArray
-            |> Array.choose (fun d ->
-                let knownProject = allKnownProjects |> Seq.tryFind (fun n -> n.ProjectFileName = d.ProjectFileName)
-
-                let isDotnetProject (knownProject: ProjectOptions option) =
-                    match knownProject with
-                    | Some p -> (p.ProjectFileName.EndsWith(".csproj") || p.ProjectFileName.EndsWith(".vbproj")) && File.Exists p.TargetPath
-                    | None -> false
-
-                if d.ProjectFileName.EndsWith ".fsproj" then
-                    knownProject
-                    |> Option.map (fun p -> FSharpReferencedProject.CreateFSharp(p.TargetPath, mapToFSharpProjectOptions p allKnownProjects))
-                elif isDotnetProject knownProject then
-                    knownProject |> Option.map loadFromDotnetDll
-                else
-                    None)
+          ProjectFileName = project.ProjectFileName
+          SourceFiles = List.toArray project.SourceFiles
+          OtherOptions = List.toArray project.OtherOptions
+          ReferencedProjects = project.ReferencedProjects |> List.toArray |> Array.choose mapProjectToReference
           IsIncompleteTypeCheckEnvironment = false
           UseScriptResolutionRules = false
-          LoadTime = projectOptions.LoadTime
+          LoadTime = project.LoadTime
           UnresolvedReferences = None // it's always None
           OriginalLoadReferences = [] // it's always empty list
           Stamp = None }
+
+    let rec private makeProjectReference isKnownProject makeFSharpProjectReference (p: ProjectReference) : FSharpReferencedProject option =
+        let knownProject = isKnownProject p
+
+        let isDotnetProject (knownProject: ProjectOptions option) =
+            match knownProject with
+            | Some p -> (p.ProjectFileName.EndsWith(".csproj") || p.ProjectFileName.EndsWith(".vbproj")) && File.Exists p.TargetPath
+            | None -> false
+
+        if p.ProjectFileName.EndsWith ".fsproj" then
+            knownProject
+            |> Option.map (fun p ->
+                let theseOptions = makeFSharpProjectReference p
+                FSharpReferencedProject.CreateFSharp(p.TargetPath, theseOptions))
+        elif isDotnetProject knownProject then
+            knownProject |> Option.map loadFromDotnetDll
+        else
+            None
+
+    let mapManyOptions (allKnownProjects: ProjectOptions seq) : FSharpProjectOptions seq =
+        seq {
+            let dict = System.Collections.Concurrent.ConcurrentDictionary<ProjectOptions, FSharpProjectOptions>()
+
+            let isKnownProject (p: ProjectReference) =
+                allKnownProjects |> Seq.tryFind (fun kp -> kp.ProjectFileName = p.ProjectFileName)
+
+            let rec makeFSharpProjectReference (p: ProjectOptions) =
+                let factory = makeProjectReference isKnownProject makeFSharpProjectReference
+                dict.GetOrAdd(p, (fun p -> makeFCSOptions factory p))
+
+            for project in allKnownProjects do
+                let thisProject =
+                    dict.GetOrAdd(project, (fun p -> makeFCSOptions (makeProjectReference isKnownProject makeFSharpProjectReference) p))
+
+                yield thisProject
+        }
+
+    let rec mapToFSharpProjectOptions (projectOptions: ProjectOptions) (allKnownProjects: ProjectOptions seq) : FSharpProjectOptions =
+        let isKnownProject (d: ProjectReference) =
+            allKnownProjects |> Seq.tryFind (fun n -> n.ProjectFileName = d.ProjectFileName)
+
+        makeFCSOptions (makeProjectReference isKnownProject (fun p -> mapToFSharpProjectOptions p allKnownProjects)) projectOptions

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -824,17 +824,11 @@ let testFCSmapManyProj toolsPath workspaceLoader (workspaceFactory: ToolsPath ->
                   | Some opts -> yield! allFCSProjects opts
                   | None -> () ]
 
-
         let rec allP2P (po: FSharpProjectOptions) =
             [ for reference in po.ReferencedProjects do
                   let opts = internalGetProjectOptions reference |> Option.get
                   yield reference.OutputFile, opts
                   yield! allP2P opts ]
-
-        let expectP2PKeyIsTargetPath (pos: Map<string, ProjectOptions>) fcsPo =
-            for (tar, fcsPO) in allP2P fcsPo do
-                let dpoPo = pos |> Map.find fcsPo.ProjectFileName
-                Expect.equal tar dpoPo.TargetPath (sprintf "p2p key is TargetPath, fsc projet options was '%A'" fcsPO)
 
         let testDir = inDir fs "load_sample_fsc"
         copyDirFromAssets fs ``sample3 Netsdk projs``.ProjDir testDir
@@ -866,6 +860,87 @@ let testFCSmapManyProj toolsPath workspaceLoader (workspaceFactory: ToolsPath ->
         Expect.equal hasFSharpProjectRef true "Should have project reference to F# reference"
     )
 
+let countDistinctObjectsByReference<'a> (items : 'a seq) =
+    let set = HashSet(items |> Seq.map (fun i -> i :> obj), ReferenceEqualityComparer.Instance)
+    set.Count
+
+let testFCSmapManyProjCheckCaching =
+    testCase |> withLog "When creating FCS options, caches them" (fun _ _ ->
+
+        let sdkInfo = ProjectLoader.getSdkInfo []
+        
+        let template : ProjectOptions =
+            { ProjectId = None
+              ProjectFileName = "Template"
+              TargetFramework = "TF"
+              SourceFiles = []
+              OtherOptions = []
+              ReferencedProjects = []
+              PackageReferences = []
+              LoadTime = DateTime.MinValue
+              TargetPath = "TP"
+              ProjectOutputType = ProjectOutputType.Library
+              ProjectSdkInfo = sdkInfo
+              Items = []
+              CustomProperties = [] }
+            
+        let makeReference (options : ProjectOptions) =
+            { RelativePath = options.ProjectFileName
+              ProjectFileName = options.ProjectFileName
+              TargetFramework = options.TargetFramework }
+            
+        let makeProject (name : string) (referencedProjects : ProjectOptions list) =
+            { template with
+                ProjectFileName = name
+                ReferencedProjects = referencedProjects |> List.map makeReference }
+            
+        let projectsInLayers =
+            let layerCount = 4
+            let layerSize = 2
+            let layers =
+                [1..layerCount]
+                |> List.map (fun layer ->
+                    [1..layerSize]
+                    |> List.map (fun item -> makeProject $"layer{layer}_{item}.fsproj" [])
+                )
+            let first = layers[0]
+            let rest =
+                layers
+                |> List.pairwise
+                |> List.map (fun (previous, next) ->
+                    next
+                    |> List.map (fun p ->
+                        { p with
+                            ReferencedProjects = previous |> List.map makeReference }
+                    )
+                )
+            let layers = first :: rest
+            
+            layers |> List.concat
+        
+        let fcsOptions = FCS.mapManyOptions projectsInLayers
+            
+        let rec findProjectOptionsTransitively (project : FSharpProjectOptions) =
+            project.ReferencedProjects
+            |> Array.toList
+            |> List.collect (fun reference ->
+                reference
+                |> internalGetProjectOptions
+                |> Option.map findProjectOptionsTransitively
+                |> Option.defaultValue [] 
+            )
+            |> List.append [project]
+                
+        let findDistinctProjectOptionsTransitively (projects : FSharpProjectOptions seq) =
+            projects
+            |> Seq.collect findProjectOptionsTransitively
+            |> countDistinctObjectsByReference
+            
+        let distinctOptionsCount = findDistinctProjectOptionsTransitively fcsOptions
+        
+        Expect.equal distinctOptionsCount projectsInLayers.Length "Mapping should reuse instances of FSharpProjectOptions and only create one per project"
+    )
+
 let testSample2WithBinLog toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase |> withLog (sprintf "can load sample2 with bin log - %s" workspaceLoader) (fun logger fs ->
         let testDir = inDir fs "load_sample2_bin_log"
@@ -873,7 +948,7 @@ let testSample2WithBinLog toolsPath workspaceLoader (workspaceFactory: ToolsPath
 
         let projPath = testDir / (``sample2 NetSdk library``.ProjectFile)
         let projDir = Path.GetDirectoryName projPath
-
+ 
         dotnet fs [ "restore"; projPath ] |> checkExitCodeZero
 
         let loader = workspaceFactory toolsPath
@@ -1289,6 +1364,7 @@ let tests toolsPath =
           //FCS multi-project tests
           testFCSmapManyProj toolsPath "WorkspaceLoader" WorkspaceLoader.Create
           testFCSmapManyProj toolsPath "WorkspaceLoaderViaProjectGraph" WorkspaceLoaderViaProjectGraph.Create
+          testFCSmapManyProjCheckCaching
           //ProjectSystem tests
           testProjectSystem toolsPath "WorkspaceLoader" WorkspaceLoader.Create
           testProjectSystem toolsPath "WorkspaceLoaderViaProjectGraph" WorkspaceLoaderViaProjectGraph.Create


### PR DESCRIPTION
Closes #155 by providing an all-in-one mapping function in addition to the one-shot mapping function. Would like to grab some of the dense tests from dotnet/fsharp to verify before merging.