### PR TITLE
README.md: Fix link to Contributing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There might be a little voice inside that tells you you're not ready; that you n
 
 I assure you, that's not the case.
 
-This project has some clear Contribution Guidelines and expectations that you can [read here](https://github.com/ionide/dotnet-proj-info/blob/master/CONTRIBUTING.md).
+This project has some clear Contribution Guidelines and expectations that you can [read here](https://github.com/ionide/dotnet-proj-info/blob/main/CONTRIBUTING.md).
 
 The contribution guidelines outline the process that you'll need to follow to get a patch merged. By making expectations and process explicit, I hope it will make it easier for you to contribute.
 


### PR DESCRIPTION
Old link was pointing to an old version of the file from before the `master -> main` rename.