### PR TITLE
Fixing 6.0.400 issues

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.201",
+    "version": "6.0.400",
     "rollForward": "minor"
   }
 }

--- a/src/Ionide.ProjInfo/Library.fs
+++ b/src/Ionide.ProjInfo/Library.fs
@@ -352,13 +352,11 @@ module ProjectLoader =
                "DefineExplicitDefaults", "true"
                "BuildProjectReferences", "false"
                "UseCommonOutputDirectory", "false"
+               "NonExistentFile", Path.Combine("__NonExistentSubDir__", "__NonExistentFile__") // Required by the Clean Target
                if tfm.IsSome then
                    "TargetFramework", tfm.Value
-               if path.EndsWith ".csproj" then
-                   "NonExistentFile", Path.Combine("__NonExistentSubDir__", "__NonExistentFile__")
                "DotnetProjInfo", "true"
                yield! globalProperties ]
-
 
     ///<summary>
     /// These are a list of build targets that are run during a design-time build (mostly).

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -597,7 +597,8 @@ let testRender3 toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorks
 
         let loader = workspaceFactory toolsPath
 
-        let parsed = loader.LoadProjects [ projPath ] |> Seq.toList
+        let projDir = Path.GetDirectoryName projPath
+        let parsed = loader.LoadProjects([ projPath ], [], BinaryLogGeneration.Within(DirectoryInfo projDir)) |> Seq.toList
 
         let l1Parsed = parsed |> expectFind l1 "the C# lib"
 


### PR DESCRIPTION
For some reason in 6.0.400, `CoreCompile` was not getting executed and theerfore we couldn't read the `FscCommandLineArgs`.  This adds `Clean` to the `designTimeBuildTargets`.

Hopefully addresses https://github.com/ionide/ionide-vscode-fsharp/issues/1748
