### PR TITLE
Create multiple pipelines for .NET SDK testing in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build for multiple SDK versions
 
 on: [push, pull_request]
 
@@ -7,23 +7,42 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        include:
+          # just use what's in the repo
+          - global-json-file: "global.json"
+            dotnet-version: ""
+            include-prerelease: false
+            label: "repo global.json"
+          # latest 6.0 stable
+          - global-json-file: "global.json"
+            dotnet-version: "6.0.x"
+            include-prerelease: false
+            label: "6.0 stable"
+          # latest 7.0 preview
+          - global-json-file: "global.json"
+            dotnet-version: "7.0.x"
+            include-prerelease: true
+            label: "7.0 preview"
       fail-fast: false # we have timing issues on some OS, so we want them all to run
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
-
+    name: Build on ${{matrix.os}} for ${{ matrix.label }}
     steps:
-      - uses: actions/checkout@v1
-      # Not specifying a version will attempt to install via global.json
+      - uses: actions/checkout@v3
+
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+          global-json-file: ${{ matrix.global-json-file }}
+          include-prerelease: ${{ matrix.include-prerelease }}
 
       - name: Restore tools
         run: dotnet tool restore
-      - name: Install latest F# from mono (.net 4.x)
-        if: runner.os == 'Linux'
-        run: ./install_mono_from_microsoft_deb_packages.sh && which msbuild
-      - name: Run build
+
+      - name: Run build and test
         run: dotnet run --project build -- -t Pack
+
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        dotnet-version: ["", "6.0.x", "7.0.x"]
+        # these entries will mesh with the above combinations
         include:
           # just use what's in the repo
           - global-json-file: "global.json"
@@ -36,6 +38,11 @@ jobs:
           dotnet-version: ${{ matrix.dotnet-version }}
           global-json-file: ${{ matrix.global-json-file }}
           include-prerelease: ${{ matrix.include-prerelease }}
+
+      # because we've set up the .NET SDK environment how we want it now, we can remove the global.json file
+      # just run raw dotnet calls
+      - name: Remove global.json
+        run: rm global.json
 
       - name: Restore tools
         run: dotnet tool restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,10 @@ jobs:
       - name: Remove global.json
         run: rm global.json
 
+      # let's make sure we're on the version we think we are.
+      - name: Announce .NET version
+        run: dotnet --info
+
       - name: Restore tools
         run: dotnet tool restore
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,20 +15,27 @@ jobs:
             dotnet-version: ""
             include-prerelease: false
             label: "repo global.json"
+            continue-on-error: false
           # latest 6.0 stable
           - global-json-file: "global.json"
             dotnet-version: "6.0.x"
             include-prerelease: false
             label: "6.0 stable"
+            continue-on-error: false
           # latest 7.0 preview
           - global-json-file: "global.json"
             dotnet-version: "7.0.x"
             include-prerelease: true
             label: "7.0 preview"
+            continue-on-error: true
       fail-fast: false # we have timing issues on some OS, so we want them all to run
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+
     name: Build on ${{matrix.os}} for ${{ matrix.label }}
+
+    # we don't want the 7-preview builds to break the PR merge, so those should be optional
+    continue-on-error: ${{ matrix.continue-on-error }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This creates 3 'channels' of builds:
* what's in the repo global.json
* latest LTS SDK version
* latest SDK version, including prereleases

and builds and tests the library against those. This should give us heads-up when things start going bad in the future. This proves that 7.0 is broken currently, so I marked those builds as optional.