### PR TITLE
Adds ClearCachesAfterBuild to GraphBuildRequestData

### DIFF
--- a/src/Ionide.ProjInfo/Library.fs
+++ b/src/Ionide.ProjInfo/Library.fs
@@ -776,7 +776,7 @@ type WorkspaceLoaderViaProjectGraph private (toolsPath, ?globalProperties: (stri
                 )
 
                 let gbr =
-                    GraphBuildRequestData(projects, ProjectLoader.designTimeBuildTargets false, null, BuildRequestDataFlags.ReplaceExistingProjectInstance)
+                    GraphBuildRequestData(projects, ProjectLoader.designTimeBuildTargets false, null, BuildRequestDataFlags.ReplaceExistingProjectInstance ||| BuildRequestDataFlags.ClearCachesAfterBuild)
 
                 let bm = BuildManager.DefaultBuildManager
                 use sw = new StringWriter()


### PR DESCRIPTION
The reason this is added is because it will force the BuildManager to pull the project files from disk per this comment: [https://github.com/dotnet/msbuild/blob/a3b647d766676a735211a42aa0726d1d940ed13d/src/Build/BackEnd/BuildManager/BuildManager.cs\#L2631-L2633](https://github.com/dotnet/msbuild/blob/a3b647d766676a735211a42aa0726d1d940ed13d/src/Build/BackEnd/BuildManager/BuildManager.cs#L2631-L2633)

- [ ] Needs tests