### PR TITLE
Exposes Properties on ProjectOptions

### DIFF
--- a/src/Ionide.ProjInfo/Library.fs
+++ b/src/Ionide.ProjInfo/Library.fs
@@ -588,6 +588,7 @@ module ProjectLoader =
               ProjectOutputType = outputType
               ProjectSdkInfo = sdkInfo
               Items = compileItems
+              Properties = List.ofSeq props
               CustomProperties = List.ofSeq customProps }
 
 
@@ -616,6 +617,7 @@ module ProjectLoader =
               "RunCommand"
               "IsPublishable"
               "BaseIntermediateOutputPath"
+              "IntermediateOutputPath"
               "TargetPath"
               "IsCrossTargetingBuild"
               "TargetFrameworks" ]

--- a/src/Ionide.ProjInfo/Types.fs
+++ b/src/Ionide.ProjInfo/Types.fs
@@ -60,6 +60,7 @@ module Types =
           ProjectOutputType: ProjectOutputType
           ProjectSdkInfo: ProjectSdkInfo
           Items: ProjectItem list
+          Properties: Property list
           CustomProperties: Property list }
 
     type CompileItem =

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -886,6 +886,7 @@ let testFCSmapManyProjCheckCaching =
               ProjectOutputType = ProjectOutputType.Library
               ProjectSdkInfo = sdkInfo
               Items = []
+              Properties = []
               CustomProperties = [] }
             
         let makeReference (options : ProjectOptions) =


### PR DESCRIPTION
This exposes the collected properties on `ProjectOptions`.  This will allow the caller to get at information like `IntermediateOutputPath` which can allow for consumers to stop hardcoding `obj` folder paths.

This can unblock: https://github.com/ionide/proj-info/issues/103 https://github.com/ionide/proj-info/issues/110