### PR TITLE
Fix access error while reading project files.

### DIFF
--- a/src/Ionide.ProjInfo.ProjectSystem/WorkspacePeek.fs
+++ b/src/Ionide.ProjInfo.ProjectSystem/WorkspacePeek.fs
@@ -45,7 +45,23 @@ module WorkspacePeek =
             let scanDir (dirInfo: DirectoryInfo) =
                 let hasExt (ext: string) (s: FileInfo) = s.FullName.EndsWith(ext)
 
-                dirInfo.EnumerateFiles("*.*", SearchOption.TopDirectoryOnly)
+                let topLevelFiles =
+                    try
+                        dirInfo.EnumerateFiles("*.*", SearchOption.TopDirectoryOnly)
+                    with
+                    | :? UnauthorizedAccessException as ex ->
+                        logger.error (
+                            Log.setMessage "Unauthorized access error while reading files of {dir}"
+                            >> Log.addContextDestructured "dir" dirInfo.Name
+                            >> Log.addExn ex
+                        )
+
+                        Seq.empty
+                    | ex ->
+                        logger.error (Log.setMessage "Failed to read files of {dir}" >> Log.addContextDestructured "dir" dirInfo.Name >> Log.addExn ex)
+                        Seq.empty
+
+                topLevelFiles
                 |> Seq.choose (fun s ->
                     match s with
                     | x when x |> hasExt ".sln" -> Some(UsefulFile.Sln, x)


### PR DESCRIPTION
This PR will fix an exception occurring from unauthorized access of a sub-directory in ``scanDirs``
This will close #174 

I created a new function for error handling and returned empty arrays to keep the sequence expression in ``scanDirs`` relatively the same. I was unsure what to do when encountering an exception so I decided to add similar logging logic to what's already present in the repository.

I'm unsure how I would add tests for this.

Any feedback would be much appreciated!
(I forgot to create a new branch on my fork... sorry about that)