### PR TITLE
guard against object disposals in the onChanhe handler

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,6 +48,11 @@
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
             "console": "internalConsole"
+        },
+        {
+            "request": "attach",
+            "type": "coreclr",
+            "name": "Attach"
         }
     ],
     "inputs": [

--- a/src/Ionide.ProjInfo.ProjectSystem/ProjectSystem.fs
+++ b/src/Ionide.ProjInfo.ProjectSystem/ProjectSystem.fs
@@ -90,7 +90,11 @@ type ProjectController(toolsPath: ToolsPath, workspaceLoaderFactory: ToolsPath -
 
     let loadProjects (files: string list) (binaryLogs: BinaryLogGeneration) =
         async {
-            let onChange fn = projectsChanged.OnNext(fn, binaryLogs)
+            let onChange fn =
+                try
+                    projectsChanged.OnNext(fn, binaryLogs)
+                with
+                | :? ObjectDisposedException -> ()
 
             let onLoaded p =
                 match p with


### PR DESCRIPTION
Fixes an exception I saw raised by the tests when attaching to them locally.