### PR TITLE
Add post build target to remove `Microsoft.Build` assemblies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,6 @@ msbuild.binlog
 .fake
 .ionide
 obj2
+
+# Rider
+.idea/

--- a/src/Ionide.ProjInfo.Tool/Ionide.ProjInfo.Tool.fsproj
+++ b/src/Ionide.ProjInfo.Tool/Ionide.ProjInfo.Tool.fsproj
@@ -17,5 +17,14 @@
         <ProjectReference Include="..\Ionide.ProjInfo.ProjectSystem\Ionide.ProjInfo.ProjectSystem.fsproj" />
     </ItemGroup>
 
-    <Import Project="..\..\.paket\Paket.Restore.targets" />
+    <Target Name="RemoveDllsAfterBuild" AfterTargets="Build">
+      <ItemGroup>
+        <FilesToDelete Include="$(TargetDir)\Microsoft.Build.dll"/>
+        <FilesToDelete Include="$(TargetDir)\Microsoft.Build.Framework.dll"/>
+      </ItemGroup>
+
+      <Delete Files="@(FilesToDelete)"/>
+    </Target>
+
+    <Import Project="..\..\.paket\Paket.Restore.targets"/>
 </Project>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 06e0b76</samp>

Add a custom target to `Ionide.ProjInfo.Tool.fsproj` to delete conflicting MSBuild DLLs after build. This fixes a runtime error caused by paket restore and updates the tool to use the latest MSBuild API.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 06e0b76</samp>

> _`paket` copies old_
> _MSBuild DLLs, tool breaks_
> _delete them in spring_

<!--
copilot:emoji
-->

:wrench::fire::arrows_counterclockwise:

<!--
1.  :wrench: - This emoji represents the tool or utility aspect of the change, as the change affects a tool that uses the MSBuild API.
2.  :fire: - This emoji represents the deletion or removal aspect of the change, as the change deletes two unwanted DLLs from the output directory.
3.  :arrows_counterclockwise: - This emoji represents the update or upgrade aspect of the change, as the change updates the tool to use the latest MSBuild API.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 06e0b76</samp>

* Add a custom target to delete unwanted MSBuild DLLs from the output directory after the build ([link](https://github.com/ionide/proj-info/pull/196/files?diff=unified&w=0#diff-843b117461d4d6fce6244730a14a725181669e5fc9c4e3dc1505d55d4151a0b1L20-R30))

This fixes https://github.com/ionide/proj-info/issues/195.
Please let me know if there are any changes you wish to see.