### PR TITLE
Add support for reference assemblies to ProjInfo

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "paket": {
-      "version": "7.2.1",
+      "version": "8.0.3",
       "commands": [
         "paket"
       ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,12 @@
         "test/examples",
         "packages"
     ],
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "cSpell.words": [
+        "binlog",
+        "inheritdoc",
+        "tfms",
+        "vswhere",
+        "xbuild"
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.63.0] - 2024-02-06
+
+### Changed
+
+* [Add support for reference assemblies to project cracking and FCS ProjectOptions mapping](https://github.com/ionide/proj-info/pull/200)
+
 ## [0.62.0] - 2023-08-21
 
 ### Changed

--- a/src/Ionide.ProjInfo.FCS/Library.fs
+++ b/src/Ionide.ProjInfo.FCS/Library.fs
@@ -49,14 +49,14 @@ module FCS =
             | Some p ->
                 (p.ProjectFileName.EndsWith(".csproj")
                  || p.ProjectFileName.EndsWith(".vbproj"))
-                && File.Exists p.TargetPath
+                && File.Exists p.ResolvedTargetPath
             | None -> false
 
         if p.ProjectFileName.EndsWith ".fsproj" then
             knownProject
-            |> Option.map (fun p ->
+            |> Option.map (fun (p: ProjectOptions) ->
                 let theseOptions = makeFSharpProjectReference p
-                FSharpReferencedProject.FSharpReference(p.TargetPath, theseOptions)
+                FSharpReferencedProject.FSharpReference(p.ResolvedTargetPath, theseOptions)
             )
         elif isDotnetProject knownProject then
             knownProject

--- a/src/Ionide.ProjInfo/Types.fs
+++ b/src/Ionide.ProjInfo/Types.fs
@@ -59,13 +59,21 @@ module Types =
         ReferencedProjects: ProjectReference list
         PackageReferences: PackageReference list
         LoadTime: DateTime
+        /// The path to the primary executable or loadable output of this project
         TargetPath: string
+        /// If present, this project produced a reference assembly and this should be used as primary reference for downstream proejcts
+        TargetRefPath: string option
         ProjectOutputType: ProjectOutputType
         ProjectSdkInfo: ProjectSdkInfo
         Items: ProjectItem list
         Properties: Property list
         CustomProperties: Property list
-    }
+    } with
+        /// ResolvedTargetPath is the path to the primary reference assembly for this project.
+        /// For projects that produce ReferenceAssemblies, this is the path to the reference assembly.
+        /// For other projects, this is the same as TargetPath.
+        member x.ResolvedTargetPath =
+            defaultArg x.TargetRefPath x.TargetPath
 
     type CompileItem = {
         Name: string

--- a/test/Ionide.ProjInfo.Tests/TestAssets.fs
+++ b/test/Ionide.ProjInfo.Tests/TestAssets.fs
@@ -280,3 +280,27 @@ let ``sample9 NetSdk library`` = {
     TargetFrameworks = Map.ofList [ "netstandard2.0", sourceFiles [ "Library.fs" ] ]
     ProjectReferences = []
 }
+
+/// dotnet sdk library with ProduceReferenceAssembly=true
+let ``NetSDK library with ProduceReferenceAssembly`` = {
+    ProjDir = "sample-netsdk-prodref"
+    AssemblyName = "l1"
+    ProjectFile =
+        "l1"
+        / "l1.fsproj"
+    TargetFrameworks = Map.ofList [ "netstandard2.0", sourceFiles [ "Library.fs" ] ]
+    ProjectReferences = []
+}
+
+
+let ``NetSDK library referencing ProduceReferenceAssembly library`` = {
+    ProjDir = "sample-netsdk-prodref"
+    AssemblyName = "l2"
+    ProjectFile =
+        "l2"
+        / "l2.fsproj"
+    TargetFrameworks = Map.ofList [ "netstandard2.0", sourceFiles [ "Library.fs" ] ]
+    ProjectReferences = [
+        ``NetSDK library with ProduceReferenceAssembly``
+    ]
+}

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -1482,6 +1482,7 @@ let testFCSmapManyProjCheckCaching =
                 PackageReferences = []
                 LoadTime = DateTime.MinValue
                 TargetPath = "TP"
+                TargetRefPath = Some "TRP"
                 ProjectOutputType = ProjectOutputType.Library
                 ProjectSdkInfo = sdkInfo
                 Items = []

--- a/test/examples/sample-netsdk-prodref/README.md
+++ b/test/examples/sample-netsdk-prodref/README.md
@@ -1,0 +1,1 @@
+a library (l1) with ProduceReferenceAssembly set to true, and another library (l2) that references l1

--- a/test/examples/sample-netsdk-prodref/l1/Library.fs
+++ b/test/examples/sample-netsdk-prodref/l1/Library.fs
@@ -1,0 +1,5 @@
+namespace n1
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/test/examples/sample-netsdk-prodref/l1/l1.fsproj
+++ b/test/examples/sample-netsdk-prodref/l1/l1.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+
+</Project>

--- a/test/examples/sample-netsdk-prodref/l2/Library.fs
+++ b/test/examples/sample-netsdk-prodref/l2/Library.fs
@@ -1,0 +1,5 @@
+namespace n1
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/test/examples/sample-netsdk-prodref/l2/l2.fsproj
+++ b/test/examples/sample-netsdk-prodref/l2/l2.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+    <ProjectReference Include="../l1/l1.fsproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds support for reading and deferring to TargetRefPath when it exists. This property points to the reference assembly that matches the _implementation_ assembly that exists in `TargetPath`. There's a new member to help navigate the proper usage. When ref assemblies are present, the FSharpReferencedProject items returned as part of a generated FSharpProjectOptions object will use the ref assembly as the source of truth, not the implementation assembly.