### PR TITLE
Remove some uses of Assembly.Location and other methods

### DIFF
--- a/src/Ionide.ProjInfo.ProjectSystem/Environment.fs
+++ b/src/Ionide.ProjInfo.ProjectSystem/Environment.fs
@@ -142,12 +142,6 @@ module Environment =
                 </> "fsc.exe"
             )
 
-    let fsharpCore =
-        let dir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)
-
-        dir
-        </> "FSharp.Core.dll"
-
     let workspaceLoadDelay () =
         match System.Environment.GetEnvironmentVariable("FSAC_WORKSPACELOAD_DELAY") with
         | delayMs when not (String.IsNullOrWhiteSpace(delayMs)) ->

--- a/src/Ionide.ProjInfo.Sln/FileUtilities.cs
+++ b/src/Ionide.ProjInfo.Sln/FileUtilities.cs
@@ -24,7 +24,7 @@ namespace Ionide.ProjInfo.Sln.Shared
 
     internal static class FileUtilitiesRegex
     {
-        // regular expression used to match file-specs beginning with "<drive letter>:" 
+        // regular expression used to match file-specs beginning with "<drive letter>:"
         internal static readonly Regex DrivePattern = new Regex(@"^[A-Za-z]:");
 
         // regular expression used to match UNC paths beginning with "\\<server>\<share>"
@@ -650,11 +650,6 @@ namespace Ionide.ProjInfo.Sln.Shared
 
         // ISO 8601 Universal time with sortable format
         internal const string FileTimeFormat = "yyyy'-'MM'-'dd HH':'mm':'ss'.'fffffff";
-
-        /// <summary>
-        /// Get the currently executing assembly path
-        /// </summary>
-        internal static string ExecutingAssemblyPath => Path.GetFullPath(Assembly.GetAssembly(typeof(FileUtilities)).Location);
 
         /// <summary>
         /// Determines the full path for the given file-spec.

--- a/src/Ionide.ProjInfo.Sln/NativeMethods.cs
+++ b/src/Ionide.ProjInfo.Sln/NativeMethods.cs
@@ -765,58 +765,6 @@ namespace Ionide.ProjInfo.Sln.Shared
         }
 
         /// <summary>
-        /// The base directory for all framework paths in Mono
-        /// </summary>
-        private static string s_frameworkBasePath;
-
-        /// <summary>
-        /// The directory of the current framework
-        /// </summary>
-        private static string s_frameworkCurrentPath;
-
-        /// <summary>
-        /// Gets the currently running framework path
-        /// </summary>
-        internal static string FrameworkCurrentPath
-        {
-            get
-            {
-                if (s_frameworkCurrentPath == null)
-                {
-                    var baseTypeLocation = Assembly.GetAssembly(typeof(string)).Location;
-
-                    s_frameworkCurrentPath =
-                        Path.GetDirectoryName(baseTypeLocation)
-                        ?? string.Empty;
-                }
-
-                return s_frameworkCurrentPath;
-            }
-        }
-
-        /// <summary>
-        /// Gets the base directory of all Mono frameworks
-        /// </summary>
-        internal static string FrameworkBasePath
-        {
-            get
-            {
-                if (s_frameworkBasePath == null)
-                {
-                    var dir = FrameworkCurrentPath;
-                    if (dir != string.Empty)
-                    {
-                        dir = Path.GetDirectoryName(dir);
-                    }
-
-                    s_frameworkBasePath = dir ?? string.Empty;
-                }
-
-                return s_frameworkBasePath;
-            }
-        }
-
-        /// <summary>
         /// System information, initialized when required.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Per [the docs](https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli#api-incompatibility) some APIs are unusable from a single-file deployment. This just removes uses of them from ProjInfo, which is easy because nothing was using any of these members anymore.