### PR TITLE
Allow loading of projects that are missing imports.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,12 +74,6 @@ jobs:
         env:
           BuildNet7: ${{ matrix.build_net7 }}
 
-      - name: Upload NuGet packages
-        uses: actions/upload-artifact@v2
-        with:
-          name: packages
-          path: src/**/*.nupkg
-
       - name: Archive test results
         uses: actions/upload-artifact@v3
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,6 @@
             "name": "Ionide.ProjInfo.Tests",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "build",
             "program": "${workspaceFolder}/test/Ionide.ProjInfo.Tests/bin/Debug/${input:tfm}/Ionide.ProjInfo.Tests.dll",
             "args": [
                 "--filter",

--- a/src/Ionide.ProjInfo/Library.fs
+++ b/src/Ionide.ProjInfo/Library.fs
@@ -1012,7 +1012,7 @@ type WorkspaceLoaderViaProjectGraph private (toolsPath, ?globalProperties: (stri
 
         handleProjectGraphFailures
         <| fun () ->
-            let per_request_collection = projectCollection ()
+            use per_request_collection = projectCollection ()
 
             paths
             |> Seq.iter (fun p -> loadingNotification.Trigger(WorkspaceProjectState.Loading p))
@@ -1272,7 +1272,7 @@ type WorkspaceLoader private (toolsPath: ToolsPath, ?globalProperties: (string *
 
         override __.LoadProjects(projects: string list, customProperties, binaryLogs) =
             let cache = Dictionary<string, ProjectOptions>()
-            let per_request_collection = projectCollection ()
+            use per_request_collection = projectCollection ()
 
             let getAllKnown () =
                 cache

--- a/src/Ionide.ProjInfo/Library.fs
+++ b/src/Ionide.ProjInfo/Library.fs
@@ -612,12 +612,6 @@ module ProjectLoader =
             let tfm = loadProjectAndGetTFM path projectCollection readingProps isLegacyFrameworkProjFile
 
             let globalProperties = getGlobalProps tfm [] collectionProps
-
-            let loadSettings =
-                ProjectLoadSettings.RecordEvaluatedItemElements
-                ||| ProjectLoadSettings.ProfileEvaluation
-                ||| ProjectLoadSettings.IgnoreMissingImports
-
             let project = findOrCreateMatchingProject path projectCollection globalProperties
             use sw = new StringWriter()
 
@@ -928,21 +922,6 @@ module ProjectLoader =
             let proj = mapToProject path commandLineArgs p2pRefs compileItems nuGetRefs sdkInfo props customProps
 
             Result.Ok proj
-
-// /// <summary>
-// /// Main entry point for project loading.
-// /// </summary>
-// /// <param name="path">Full path to the `.fsproj` file</param>
-// /// <param name="binaryLogs">describes if and how to generate MsBuild binary logs</param>
-// /// <param name="projectCollection">The propertyCollection to load the project into. This will provide global properties by default.</param>
-// /// <param name="customProperties">List of additional MsBuild properties that you want to obtain.</param>
-// /// <returns>Returns the record instance representing the loaded project or string containing error message</returns>
-// let getProjectInfo (path: string) projectCollection (binaryLogs: BinaryLogGeneration) (customProperties: string list) : Result<Types.ProjectOptions, string> =
-//     let loadedProject = loadProject path binaryLogs projectCollection
-
-//     match loadedProject with
-//     | ProjectLoadingStatus.Success project -> getLoadedProjectInfo path customProperties project
-//     | ProjectLoadingStatus.Error e -> Result.Error e
 
 /// A type that turns project files or solution files into deconstructed options.
 /// Use this in conjunction with the other ProjInfo libraries to turn these options into

--- a/src/Ionide.ProjInfo/Library.fs
+++ b/src/Ionide.ProjInfo/Library.fs
@@ -331,10 +331,10 @@ module ProjectLoader =
 
     type LoadedProject = internal LoadedProject of ProjectInstance
 
-    let internal projectLoaderLogger = LogProvider.getLoggerByName "ProjectLoader"
+    let internal projectLoaderLogger = lazy (LogProvider.getLoggerByName "ProjectLoader")
 
     let msBuildToLogProvider () =
-        let msBuildLogger = (LogProvider.getLoggerByName "MsBuild") //lazy because dotnet test wont pickup our logger otherwise
+        let msBuildLogger = LogProvider.getLoggerByName "MsBuild"
 
         { new ILogger with
             member this.Initialize(eventSource: IEventSource) : unit =
@@ -637,7 +637,7 @@ module ProjectLoader =
             else
                 Error(sw.ToString())
         with exc ->
-            projectLoaderLogger.error (
+            projectLoaderLogger.Value.error (
                 Log.setMessage "Generic error while loading project {path}"
                 >> Log.addExn exc
                 >> Log.addContextDestructured "path" path

--- a/src/Ionide.ProjInfo/Library.fs
+++ b/src/Ionide.ProjInfo/Library.fs
@@ -571,9 +571,7 @@ module ProjectLoader =
                 ||| ProjectLoadSettings.ProfileEvaluation
                 ||| ProjectLoadSettings.IgnoreMissingImports
 
-            let project =
-                Project(projectFile = path, globalProperties = globalProperties, toolsVersion = null, projectCollection = projectCollection, loadSettings = loadSettings)
-
+            let project = findOrCreateMatchingProject path projectCollection globalProperties
             use sw = new StringWriter()
 
             let loggers = createLoggers [ path ] binaryLogs sw

--- a/test/Ionide.ProjInfo.Tests/TestAssets.fs
+++ b/test/Ionide.ProjInfo.Tests/TestAssets.fs
@@ -300,7 +300,15 @@ let ``NetSDK library referencing ProduceReferenceAssembly library`` = {
         "l2"
         / "l2.fsproj"
     TargetFrameworks = Map.ofList [ "netstandard2.0", sourceFiles [ "Library.fs" ] ]
-    ProjectReferences = [
-        ``NetSDK library with ProduceReferenceAssembly``
-    ]
+    ProjectReferences = [ ``NetSDK library with ProduceReferenceAssembly`` ]
+}
+
+let ``Console app with missing direct Import`` = {
+    ProjDir = "missing-import"
+    AssemblyName = "missing-import"
+    ProjectFile =
+        "missing-import"
+        / "missing-import.fsproj"
+    TargetFrameworks = Map.ofList [ "net6.0", sourceFiles [ "Program.fs" ] ]
+    ProjectReferences = []
 }

--- a/test/Ionide.ProjInfo.Tests/TestAssets.fs
+++ b/test/Ionide.ProjInfo.Tests/TestAssets.fs
@@ -306,9 +306,7 @@ let ``NetSDK library referencing ProduceReferenceAssembly library`` = {
 let ``Console app with missing direct Import`` = {
     ProjDir = "missing-import"
     AssemblyName = "missing-import"
-    ProjectFile =
-        "missing-import"
-        / "missing-import.fsproj"
+    ProjectFile = "missing-import.fsproj"
     TargetFrameworks = Map.ofList [ "net6.0", sourceFiles [ "Program.fs" ] ]
     ProjectReferences = []
 }

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -365,7 +365,7 @@ let testLegacyFrameworkMultiProject toolsPath workspaceLoader isRelease (workspa
 let testSample2 toolsPath workspaceLoader isRelease (workspaceFactory: ToolsPath * (string * string) list -> IWorkspaceLoader) =
     testCase
     |> withLog
-        (sprintf "can load sample2 - %s - isRelease is %b" workspaceLoader isRelease)
+        (sprintf "can load sample2 - isRelease is %b - %s" isRelease workspaceLoader)
         (fun logger fs ->
             let testDir = inDir fs "load_sample2"
             copyDirFromAssets fs ``sample2 NetSdk library``.ProjDir testDir

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -2068,7 +2068,7 @@ let addFileToProject (projPath: string) fileName =
 let loadProjfileFromDiskTests toolsPath workspaceLoader (workspaceFactory: ToolsPath -> IWorkspaceLoader) =
     testCase
     |> withLog
-        $"can load project from disk everytime {workspaceLoader}"
+        $"can load project from disk everytime - {workspaceLoader}"
         (fun logger fs ->
 
             let loader = workspaceFactory toolsPath

--- a/test/examples/missing-import/Program.fs
+++ b/test/examples/missing-import/Program.fs
@@ -1,0 +1,3 @@
+[<EntryPoint>]
+let main args =
+    1

--- a/test/examples/missing-import/missing-import.fsproj
+++ b/test/examples/missing-import/missing-import.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>missing_import</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildExtensionsPath)Foo\Foo.targets" />
+
+</Project>


### PR DESCRIPTION
Fixes #205.

This one got away from me a bit, but I think it's for the best.

## The Problem

To load project files with missing Imports, we need to supply one or two ProjectLoadSettings flags to everywhere a project file could be parsed. These flags are `ProjectLoadSettings.IgnoreMissingImports` and `ProjectLoadSettings.IgnoreInvalidImports`. Ideally we need to find everywhere that a project would be loaded (so anywhere `Project(...)` or `ProjectInstance(...)` occur) and make sure these flags are applied.

## Phase 1 - protecting the main constructors

For our purposes there are two main places that `ProjectLoadSettings` can be specified
* when the `Project` constructor is called in the `WorkspaceLoader`
* as part of the `buildParameters` for the `WorkspaceLoaderViaProjectGraph`

Applying these changes to the existing call-sites was fairly easy - there were something like 6 places that Projects/Project Instances were directly created. Here we come to our first hurdle - the `ProjectInstance` constructor doesn't surface `ProjectLoadSettings` in any way. So step one was to turn any sort of `ProjectInstance` creation into a two-phase operation:
* create the `Project` with appropriate load settings
* create the `ProjectInstance` from that `Project`

This got us most of the way through the tests.

## Phase 2 - TFM detection

With one hurdle - the way we detected the TFM for a project involved loading a `ProjectInstance` directly and reading properties from it, and this turned out to be error prone because of the reasons mentioned above - `ProjectInstance` doesn't have `ProjectLoadSettings`. So we needed to create a `Project` to get the `ProjectInstance` from, as described above.

## Phase 3 - ProjectCollection management

The above fix worked for more tests, but others still failed because the 'same project' was being created (and implicitly assigned to the global `ProjectCollection`) multiple times - a big no-no for `ProjectCollections`. So this required two changes:
* create and manage a `ProjectCollection` as a 'container' for a given call to `LoadProjects` - this allows us to cache the evaluations and design-time builds over the course of a single call to `LoadProjects` while also not cluttering/clobbering the global default `ProjectCollection`
* implement a function that safely retrieves an existing `Project` from the `ProjectCollection` if one exists for the same project path + global properties - if not, a new `Project` is created. 

With these two changes, all the tests (including the new tests) became green.