### PR TITLE
Support traversal projects

### DIFF
--- a/test/Ionide.ProjInfo.Tests/FileUtils.fs
+++ b/test/Ionide.ProjInfo.Tests/FileUtils.fs
@@ -141,7 +141,7 @@ let createFile (logger: Logger) path setContent =
     setContent f
     ()
 
-let unzip (logger: Logger) file dir =
+let unzip (logger: Logger) (file: string) (dir: string) =
     logger.debug (
         eventX "unzip '{file}' to {directory}"
         >> setField "file" file

--- a/test/Ionide.ProjInfo.Tests/TestAssets.fs
+++ b/test/Ionide.ProjInfo.Tests/TestAssets.fs
@@ -310,3 +310,14 @@ let ``Console app with missing direct Import`` = {
     TargetFrameworks = Map.ofList [ "net6.0", sourceFiles [ "Program.fs" ] ]
     ProjectReferences = []
 }
+
+let ``traversal project`` = {
+    ProjDir = "traversal-project"
+    AssemblyName = ""
+    ProjectFile = "dirs.proj"
+    TargetFrameworks = Map.empty
+    ProjectReferences = [
+        yield ``sample3 Netsdk projs``
+        yield! ``sample3 Netsdk projs``.ProjectReferences
+    ]
+}

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -1770,7 +1770,8 @@ let testLoadProject toolsPath =
             | Result.Error err -> failwith $"{err}"
             | Result.Ok proj ->
                 match ProjectLoader.getLoadedProjectInfo projPath [] proj with
-                | Result.Ok proj -> Expect.equal proj.ProjectFileName projPath "project file names"
+                | Ok(ProjectLoader.LoadedProjectInfo.StandardProjectInfo proj) -> Expect.equal proj.ProjectFileName projPath "project file names"
+                | Ok(ProjectLoader.LoadedProjectInfo.TraversalProjectInfo refs) -> failwith "expected standard project, not a traversal project"
                 | Result.Error err -> failwith $"{err}"
         )
 
@@ -2225,9 +2226,9 @@ let canLoadMissingImports toolsPath loaderType (workspaceFactory: ToolsPath -> I
             Expect.stringEnds parsed.SourceFiles[2] "Program.fs" "Filename should be Program.fs"
         )
 
-let traversalProjectTest toolsPath workspaceFactory =
+let traversalProjectTest toolsPath loaderType workspaceFactory =
     testCase
-        $"can crack traversal projects"
+        $"can crack traversal projects - {loaderType}"
         (fun () ->
             let logger = Log.create "Test 'can crack traversal projects'"
             let fs = FileUtils(logger)
@@ -2374,5 +2375,6 @@ let tests toolsPath =
         canLoadMissingImports toolsPath (nameof (WorkspaceLoader)) WorkspaceLoader.Create
         canLoadMissingImports toolsPath (nameof (WorkspaceLoaderViaProjectGraph)) WorkspaceLoaderViaProjectGraph.Create
 
-        traversalProjectTest toolsPath WorkspaceLoader.Create
+        traversalProjectTest toolsPath (nameof (WorkspaceLoader)) WorkspaceLoader.Create
+        traversalProjectTest toolsPath (nameof (WorkspaceLoaderViaProjectGraph)) WorkspaceLoaderViaProjectGraph.Create
     ]

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -2225,6 +2225,31 @@ let canLoadMissingImports toolsPath loaderType (workspaceFactory: ToolsPath -> I
             Expect.stringEnds parsed.SourceFiles[2] "Program.fs" "Filename should be Program.fs"
         )
 
+let traversalProjectTest toolsPath workspaceFactory =
+    testCase
+        $"can crack traversal projects"
+        (fun () ->
+            let logger = Log.create "Test 'can crack traversal projects'"
+            let fs = FileUtils(logger)
+            let projPath = pathForProject ``traversal project``
+            // // need to build the projects first so that there's something to latch on to
+            // dotnet fs [
+            //     "build"
+            //     projPath
+            //     "-bl"
+            // ]
+            // |> checkExitCodeZero
+
+            let loader: IWorkspaceLoader = workspaceFactory toolsPath
+
+            let parsed =
+                loader.LoadProjects [ projPath ]
+                |> Seq.toList
+
+            Expect.hasLength parsed 3 "Should have loaded the 3 referenced projects from the traversal project"
+
+        )
+
 let tests toolsPath =
     let testSample3WorkspaceLoaderExpected = [
         ExpectNotification.loading "c1.fsproj"
@@ -2348,4 +2373,6 @@ let tests toolsPath =
         // tests that cover our ability to handle missing imports
         canLoadMissingImports toolsPath (nameof (WorkspaceLoader)) WorkspaceLoader.Create
         canLoadMissingImports toolsPath (nameof (WorkspaceLoaderViaProjectGraph)) WorkspaceLoaderViaProjectGraph.Create
+
+        traversalProjectTest toolsPath WorkspaceLoader.Create
     ]

--- a/test/examples/traversal-project/dirs.proj
+++ b/test/examples/traversal-project/dirs.proj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.Build.Traversal/4.1.0">
+ <ItemGroup>
+  <ProjectReference Include="../sample3-netsdk-projs/**/*.*proj" />
+ </ItemGroup>
+</Project>


### PR DESCRIPTION
Traversal projects are a nice alternative to solutions, but they don't have great IDE support because they lack many of the targets/properties that 'normal' projects have. This PR introduces support for traversal projects basically by detecting them just enough to get their ProjectReferences, and then doing nothing else with them.
