### PR TITLE
Add clearer message on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,5 @@ msbuild.binlog
 .fake
 .ionide
 obj2
+
+.idea/


### PR DESCRIPTION
This PR is because the message I got from Ionide was very cryptic when it was unable to parse the "you don't have a compatible .NET installed" message.

(I can't even build proj-info locally because I can't install Paket, because NuGet.org appears to be having an intermittent outage: `dotnet` thinks api.nuget.org doesn't exist even with `--no-cache`, and I just saw a pipeline fail to perform a NuGet install. Just another day in .NET.)