### PR TITLE
Add CompileItem metadata to types

### DIFF
--- a/src/Ionide.ProjInfo/Library.fs
+++ b/src/Ionide.ProjInfo/Library.fs
@@ -742,6 +742,10 @@ module ProjectLoader =
                 Name = name
                 FullPath = fullPath
                 Link = link
+                Metadata =
+                    p.Metadata
+                    |> Seq.map (fun pm -> pm.Name, pm.EvaluatedValue)
+                    |> Map.ofSeq
             }
         )
 
@@ -1587,7 +1591,7 @@ module ProjectViewer =
             sources
             |> List.choose (
                 function
-                | ProjectItem.Compile(name, fullPath) -> Some(name, fullPath)
+                | ProjectItem.Compile(name, fullPath, _) -> Some(name, fullPath)
             )
             |> List.filter (fun (_, p) -> includeSourceFile p)
 

--- a/src/Ionide.ProjInfo/VisualTree.fs
+++ b/src/Ionide.ProjInfo/VisualTree.fs
@@ -75,11 +75,11 @@ module VisualTree =
                 projPath
                 |> getVisualPath None (Some sourceFile) sourceFile
 
-            ProjectItem.Compile(name, fullpath)
+            ProjectItem.Compile(name, fullpath, None)
         | Some p ->
 
             let (name, fullpath) =
                 projPath
                 |> getVisualPath p.Link (Some p.FullPath) p.Name
 
-            ProjectItem.Compile(name, fullpath)
+            ProjectItem.Compile(name, fullpath, Some p.Metadata)


### PR DESCRIPTION
I'm looking at writing something Myriad-like which also has access to the typed AST and other such compiler information, and it would really help if I could pick up configuration from the project file. Myriad itself [does this directly in MsBuild rules](https://github.com/MoiraeSoftware/myriad/blob/3c9818faabf9d508c10c28d5ecd26e66fafb48a1/src/Myriad.Sdk/build/Myriad.Sdk.targets#L96), but I would like to program in a language that is not MsBuild-flavoured XML, so I'd like to use proj-info to get the build graph and work out what I need to generate.