### PR TITLE
Add PackageReference metadata

### DIFF
--- a/src/Ionide.ProjInfo/Library.fs
+++ b/src/Ionide.ProjInfo/Library.fs
@@ -45,10 +45,14 @@ module SdkDiscovery =
             |> Seq.toArray
 
         p.WaitForExit()
+
         if p.ExitCode = 0 then
             output
         elif failOnError then
-            let output = output |> String.concat "\n"
+            let output =
+                output
+                |> String.concat "\n"
+
             failwith $"`{binaryFullPath.FullName} {args}` failed with exit code %i{p.ExitCode}. Output: %s{output}"
         else
             // for the legacy VS flow, whose behaviour is harder to test, we maintain compatibility with how proj-info
@@ -760,10 +764,16 @@ module ProjectLoader =
             let version = p.GetMetadataValue "NuGetPackageVersion"
             let fullPath = p.GetMetadataValue "FullPath"
 
+            let metadata =
+                p.Metadata
+                |> Seq.map (fun md -> md.Name, md.EvaluatedValue)
+                |> readOnlyDict
+
             {
                 Name = name
                 Version = version
                 FullPath = fullPath
+                Metadata = metadata
             }
         )
 

--- a/src/Ionide.ProjInfo/Types.fs
+++ b/src/Ionide.ProjInfo/Types.fs
@@ -1,6 +1,7 @@
 namespace Ionide.ProjInfo
 
 open System
+open System.Collections.Generic
 
 module Types =
 
@@ -38,9 +39,16 @@ module Types =
     type Property = { Name: string; Value: string }
 
     type PackageReference = {
+        /// Name of the NuGet package, e.g. "FSharp.Core".
         Name: string
+        /// Version of the NuGet package, e.g. "8.0.400".
         Version: string
+        /// Path to the DLL on disk whose import is implied by this PackageReference.
+        /// This is likely somewhere within the local NuGet cache.
+        ///
+        /// E.g. "/Users/user/.nuget/packages/fsharp.core/6.0.1/lib/netstandard2.1/FSharp.Core.dll".
         FullPath: string
+        Metadata: IReadOnlyDictionary<string, string>
     }
 
     type ProjectOutputType =
@@ -69,11 +77,11 @@ module Types =
         Properties: Property list
         CustomProperties: Property list
     } with
+
         /// ResolvedTargetPath is the path to the primary reference assembly for this project.
         /// For projects that produce ReferenceAssemblies, this is the path to the reference assembly.
         /// For other projects, this is the same as TargetPath.
-        member x.ResolvedTargetPath =
-            defaultArg x.TargetRefPath x.TargetPath
+        member x.ResolvedTargetPath = defaultArg x.TargetRefPath x.TargetPath
 
     /// Represents a `<Compile>` node within an fsproj file.
     type CompileItem = {


### PR DESCRIPTION
I would like my Myriad-like source generator system to be able to see the line `<PackageReference Include="MyCoolPlugin" WhippetPlugin="true" PrivateAssets="all" />`. That is, I would like "register this plugin with [Whippet](https://github.com/Smaug123/WoofWare.Whippet)" to be as simple as "add `WhippetPlugin="true"` to the NuGet import". To do that, I need access to the package metadata.

I have made no attempt to filter out any metadata which has already been stored somewhere. In practice, these dictionaries seem to be fewer than 10 elements big.

Whitespace changes are the result of `dotnet fantomas .`.

I've checked after merging https://github.com/ionide/proj-info/pull/216 that all the information I require is now present in the `PackageReference` output list.