### PR TITLE
Tweaks to solution filter loading

### DIFF
--- a/test/Ionide.ProjInfo.Tests/TestAssets.fs
+++ b/test/Ionide.ProjInfo.Tests/TestAssets.fs
@@ -329,3 +329,23 @@ let ``sample 11 sln with other project types`` = {
     TargetFrameworks = Map.empty
     ProjectReferences = []
 }
+
+let ``sample 12 slnf with one project`` = {
+    ProjDir = "sample12-solution-filter-with-one-project"
+    AssemblyName = ""
+    ProjectFile = "sample12-solution-filter-with-one-project.slnf"
+    TargetFrameworks = Map.empty
+    ProjectReferences = [
+        {
+            ProjDir =
+                "sample12-solution-filter-with-one-project"
+                / "classlibf2"
+            AssemblyName = "lclasslibf2"
+            ProjectFile =
+                "classlibf2"
+                / "classlibf2.fsproj"
+            TargetFrameworks = Map.ofList [ "netstandard8.0", sourceFiles [ "Library.fs" ] ]
+            ProjectReferences = []
+        }
+    ]
+}

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -2273,6 +2273,36 @@ let sample11OtherProjectsTest toolsPath loaderType workspaceFactory =
             Expect.hasLength parsed 1 "Should have fsproj"
         )
 
+let sample12SlnFilterTest toolsPath loaderType workspaceFactory =
+    testCase
+        $"Can load sample12 with solution folder with one project - {loaderType}"
+        (fun () ->
+
+            let projPath = pathForProject ``sample 12 slnf with one project``
+
+            let projPaths =
+                // using Inspectsln emulates what we do in FsAutocomplete for gathering projects to load
+                InspectSln.tryParseSln projPath
+                |> getResult
+                |> InspectSln.loadingBuildOrder
+
+            let loader: IWorkspaceLoader = workspaceFactory toolsPath
+
+            let parsed =
+                loader.LoadProjects projPaths
+                |> Seq.toList
+
+            Expect.hasLength parsed 1 "Should have fsproj"
+
+            let projDir = Path.GetDirectoryName projPath
+
+            let fsproj =
+                projDir
+                / ``sample 12 slnf with one project``.ProjectReferences.[0].ProjectFile
+
+            Expect.equal parsed[0].ProjectFileName fsproj "should contain the expected project"
+        )
+
 let tests toolsPath =
     let testSample3WorkspaceLoaderExpected = [
         ExpectNotification.loading "c1.fsproj"
@@ -2402,4 +2432,7 @@ let tests toolsPath =
 
         sample11OtherProjectsTest toolsPath (nameof (WorkspaceLoader)) WorkspaceLoader.Create
         sample11OtherProjectsTest toolsPath (nameof (WorkspaceLoaderViaProjectGraph)) WorkspaceLoaderViaProjectGraph.Create
+
+        sample12SlnFilterTest toolsPath (nameof (WorkspaceLoader)) WorkspaceLoader.Create
+        sample12SlnFilterTest toolsPath (nameof (WorkspaceLoaderViaProjectGraph)) WorkspaceLoaderViaProjectGraph.Create
     ]

--- a/test/examples/sample12-solution-filter-with-one-project/classlibf1/Library.fs
+++ b/test/examples/sample12-solution-filter-with-one-project/classlibf1/Library.fs
@@ -1,0 +1,5 @@
+﻿namespace classlibf1
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/test/examples/sample12-solution-filter-with-one-project/classlibf1/classlibf1.fsproj
+++ b/test/examples/sample12-solution-filter-with-one-project/classlibf1/classlibf1.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+
+</Project>

--- a/test/examples/sample12-solution-filter-with-one-project/classlibf2/Library.fs
+++ b/test/examples/sample12-solution-filter-with-one-project/classlibf2/Library.fs
@@ -1,0 +1,5 @@
+﻿namespace classlibf1
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/test/examples/sample12-solution-filter-with-one-project/classlibf2/classlibf2.fsproj
+++ b/test/examples/sample12-solution-filter-with-one-project/classlibf2/classlibf2.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+
+</Project>

--- a/test/examples/sample12-solution-filter-with-one-project/sample12-solution-filter-with-one-project.slnf
+++ b/test/examples/sample12-solution-filter-with-one-project/sample12-solution-filter-with-one-project.slnf
@@ -1,0 +1,8 @@
+{
+  "solution": {
+    "path": "sample12-solution-with-two-projects.sln",
+    "projects": [
+      "classlibf2\\classlibf2.fsproj"
+    ]
+  }
+}

--- a/test/examples/sample12-solution-filter-with-one-project/sample12-solution-with-two-projects.sln
+++ b/test/examples/sample12-solution-filter-with-one-project/sample12-solution-with-two-projects.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "classlibf2", "classlibf2\classlibf2.fsproj", "{33979FCF-E6B6-9D63-2EE4-C57768538882}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "classlibf1", "classlibf1\classlibf1.fsproj", "{E62CCF4F-11A1-8E40-9021-4C8FB585B5F2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{33979FCF-E6B6-9D63-2EE4-C57768538882}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33979FCF-E6B6-9D63-2EE4-C57768538882}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33979FCF-E6B6-9D63-2EE4-C57768538882}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33979FCF-E6B6-9D63-2EE4-C57768538882}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E62CCF4F-11A1-8E40-9021-4C8FB585B5F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E62CCF4F-11A1-8E40-9021-4C8FB585B5F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E62CCF4F-11A1-8E40-9021-4C8FB585B5F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E62CCF4F-11A1-8E40-9021-4C8FB585B5F2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
refs https://github.com/ionide/ionide-vscode-fsharp/issues/1708

As mentioned in https://github.com/ionide/ionide-vscode-fsharp/issues/1708#issuecomment-2883426891, when I try to load a solution filter for one of my projects in Ionide 7.25.8 I don't get any projects loaded for the solution.
(I do get the guid entries described in https://github.com/ionide/ionide-vscode-fsharp/issues/2067, but that's a different issue).

So - I had a go at adding a new unit test for a solution / solution filter pair, and when I tried debugging that I found:

1) When it read the path to the solution file out of the filter file, it only got the file name of the parent solution rather than the path (the solution and filter are in the same directory). It then failed to load that solution.
So - try to fix that by getting the absolute path to the parent solution based on the path to the solution filter.

2) When parseSln is called with a filter list, it calls makeAbsoluteFromSlnDir on each project in the parent solution when searching in the filter list. That failed to match anything if the paths in the filter are relative rather than absolute. Try to fix that by calling makeAbsoluteFromSlnDir on each project in the filter file, before loading the parent solution with them.

I tried dropping the modified ProjInfo dll into my Ionide install and that appeared to fix it for my solution, but I'm working all this out as I go along so I'm not sure if this is correct and/or complete approach.