### PR TITLE
Make InspectSln.parseFolder return the list of files in a folder

### DIFF
--- a/src/Ionide.ProjInfo/InspectSln.fs
+++ b/src/Ionide.ProjInfo/InspectSln.fs
@@ -97,9 +97,16 @@ module InspectSln =
                             not (isNull item.Parent)
                             && item.Parent.Id = folder.Id
                         )
-                        |> Seq.map (fun p -> parseItem p, string p.Id)
-                        |> List.ofSeq
-                        |> List.unzip
+                        |> Seq.map (fun p -> parseItem p)
+                        |> List.ofSeq,
+
+                        folder.Files
+                        |> Option.ofObj
+                        |> Option.map (
+                            Seq.map makeAbsoluteFromSlnDir
+                            >> List.ofSeq
+                        )
+                        |> Option.defaultValue []
                     )
             }
 

--- a/test/Ionide.ProjInfo.Tests/TestAssets.fs
+++ b/test/Ionide.ProjInfo.Tests/TestAssets.fs
@@ -349,3 +349,11 @@ let ``sample 12 slnf with one project`` = {
         }
     ]
 }
+
+let ``sample 13 sln with solution files`` = {
+    ProjDir = "sample13-solution-with-solution-files"
+    AssemblyName = ""
+    ProjectFile = "sample13-solution-with-solution-files.sln"
+    TargetFrameworks = Map.empty
+    ProjectReferences = []
+}

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -2303,6 +2303,34 @@ let sample12SlnFilterTest toolsPath loaderType workspaceFactory =
             Expect.equal parsed[0].ProjectFileName fsproj "should contain the expected project"
         )
 
+let sample13SolutionFilesTest toolsPath loaderType workspaceFactory =
+    testCase
+        $"Can load sample13 sln with solution files - {loaderType}"
+        (fun () ->
+
+            let projPath = pathForProject ``sample 13 sln with solution files``
+            let projDir = Path.GetDirectoryName projPath
+
+            let expectedReadme =
+                projDir
+                / "README.md"
+
+            let solutionContents =
+                InspectSln.tryParseSln projPath
+                |> getResult
+
+            let solutionItem = solutionContents.Items[0]
+
+            Expect.equal solutionItem.Guid (Guid("8ec462fd-d22e-90a8-e5ce-7e832ba40c5d")) "Should have the epxcted guid"
+            Expect.equal solutionItem.Name "\\Solution Items\\" "Should have the expected folder name"
+
+            match solutionItem.Kind with
+            | InspectSln.Folder(_, files) ->
+                Expect.hasLength files 1 "Should have one file"
+                Expect.sequenceEqual files [ expectedReadme ] "Should contain the expected readme.md"
+            | _ -> failtestf "Expected a folder, but got %A" solutionItem.Kind
+        )
+
 let tests toolsPath =
     let testSample3WorkspaceLoaderExpected = [
         ExpectNotification.loading "c1.fsproj"
@@ -2435,4 +2463,7 @@ let tests toolsPath =
 
         sample12SlnFilterTest toolsPath (nameof (WorkspaceLoader)) WorkspaceLoader.Create
         sample12SlnFilterTest toolsPath (nameof (WorkspaceLoaderViaProjectGraph)) WorkspaceLoaderViaProjectGraph.Create
+
+        sample13SolutionFilesTest toolsPath (nameof (WorkspaceLoader)) WorkspaceLoader.Create
+        sample13SolutionFilesTest toolsPath (nameof (WorkspaceLoaderViaProjectGraph)) WorkspaceLoaderViaProjectGraph.Create
     ]

--- a/test/examples/sample13-solution-with-solution-files/README.md
+++ b/test/examples/sample13-solution-with-solution-files/README.md
@@ -1,0 +1,3 @@
+# Ionide.ProjInfo
+
+Hello world

--- a/test/examples/sample13-solution-with-solution-files/sample13-solution-with-solution-files.sln
+++ b/test/examples/sample13-solution-with-solution-files/sample13-solution-with-solution-files.sln
@@ -1,0 +1,19 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
refs #231

As discussed in #231 I believe that it did this before the change to use the new MS solution parser, and changing it to return guids instead doesn't seem right.

Also added a new test with a solution that contains a folder with just files (no project items)