### PR TITLE
Set the Name property of folders to the display name instead of the path

### DIFF
--- a/src/Ionide.ProjInfo/InspectSln.fs
+++ b/src/Ionide.ProjInfo/InspectSln.fs
@@ -89,7 +89,7 @@ module InspectSln =
 
             let parseFolder (folder: Model.SolutionFolderModel) : SolutionItem = {
                 Guid = folder.Id
-                Name = makeAbsoluteFromSlnDir folder.Path
+                Name = folder.ActualDisplayName
                 Kind =
                     SolutionItemKind.Folder(
                         sln.SolutionItems


### PR DESCRIPTION
refs https://github.com/ionide/proj-info/pull/233#discussion_r2094469723

The version prior to the solution library change was using the name of folders rather than the path - https://github.com/ionide/proj-info/blob/912538a84ea051c56a30cf5592216b5160fe6968/src/Ionide.ProjInfo/InspectSln.fs#L78 - and that seems to be what things higher up the stack are expecting for folders