### PR TITLE
Fix the 'sample13 sln with solution files' test

### DIFF
--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -2322,7 +2322,7 @@ let sample13SolutionFilesTest toolsPath loaderType workspaceFactory =
             let solutionItem = solutionContents.Items[0]
 
             Expect.equal solutionItem.Guid (Guid("8ec462fd-d22e-90a8-e5ce-7e832ba40c5d")) "Should have the epxcted guid"
-            Expect.equal solutionItem.Name $"{Path.DirectorySeparatorChar}Solution Items{Path.DirectorySeparatorChar}" "Should have the expected folder name"
+            Expect.equal solutionItem.Name "Solution Items" "Should have the expected folder name"
 
             match solutionItem.Kind with
             | InspectSln.Folder(_, files) ->


### PR DESCRIPTION
One of the previpis 2 PRs added a new test that expected the folder name to include path separator characters, and then the other fixed it so that the folder names are just the names with no separators, so the two didn't get on with each other