### PR TITLE
Fix URI format exception in relative path computation

### DIFF
--- a/src/Ionide.ProjInfo/VisualTree.fs
+++ b/src/Ionide.ProjInfo/VisualTree.fs
@@ -20,9 +20,7 @@ module VisualTree =
             + Path.DirectorySeparatorChar.ToString()
 
     let relativePathOf fromPath toPath =
-        let fromUri = Uri(fromPath)
-        let toUri = Uri(toPath)
-        fromUri.MakeRelativeUri(toUri).OriginalString
+        Path.GetRelativePath(fromPath, toPath).Replace('\\', '/')
 
     let relativeToProjDir projPath filePath =
         filePath

--- a/test/Ionide.ProjInfo.Tests/Program.fs
+++ b/test/Ionide.ProjInfo.Tests/Program.fs
@@ -13,6 +13,9 @@ let toolsPath = Init.init (IO.DirectoryInfo Environment.CurrentDirectory) None
 [<Tests>]
 let tests = Tests.tests toolsPath
 
+[<Tests>]
+let visualTreeTests = Tests.visualTreeTests
+
 
 [<EntryPoint>]
 let main argv =

--- a/test/Ionide.ProjInfo.Tests/Tests.fs
+++ b/test/Ionide.ProjInfo.Tests/Tests.fs
@@ -2465,6 +2465,70 @@ let sample16SolutionFoldersSlnxTest toolsPath loaderType workspaceFactory =
 
     testCase $"Can load sample16 solution folders test (.slnx) - {loaderType}" (fun () -> sample16SolutionFoldersTest ``sample 16 solution folders (.slnx)``)
 
+let visualTreeTests =
+    testList "VisualTree" [
+        test "relativePathOf returns relative path for file in subdirectory" {
+            let fromPath =
+                if Environment.OSVersion.Platform = PlatformID.Win32NT then
+                    @"C:\projects\myproj\"
+                else
+                    "/projects/myproj/"
+
+            let toPath =
+                if Environment.OSVersion.Platform = PlatformID.Win32NT then
+                    @"C:\projects\myproj\src\File.fs"
+                else
+                    "/projects/myproj/src/File.fs"
+
+            let result = VisualTree.relativePathOf fromPath toPath
+            Expect.equal result "src/File.fs" "should return relative path with forward slashes"
+        }
+
+        test "relativePathOf returns relative path for sibling directory" {
+            let fromPath =
+                if Environment.OSVersion.Platform = PlatformID.Win32NT then
+                    @"C:\projects\myproj\src\"
+                else
+                    "/projects/myproj/src/"
+
+            let toPath =
+                if Environment.OSVersion.Platform = PlatformID.Win32NT then
+                    @"C:\projects\myproj\tests\Test.fs"
+                else
+                    "/projects/myproj/tests/Test.fs"
+
+            let result = VisualTree.relativePathOf fromPath toPath
+            Expect.equal result "../tests/Test.fs" "should return relative path going up then down"
+        }
+
+        test "relativePathOf returns filename for file in same directory" {
+            let fromPath =
+                if Environment.OSVersion.Platform = PlatformID.Win32NT then
+                    @"C:\projects\myproj\"
+                else
+                    "/projects/myproj/"
+
+            let toPath =
+                if Environment.OSVersion.Platform = PlatformID.Win32NT then
+                    @"C:\projects\myproj\File.fs"
+                else
+                    "/projects/myproj/File.fs"
+
+            let result = VisualTree.relativePathOf fromPath toPath
+            Expect.equal result "File.fs" "should return just the filename"
+        }
+
+        test "relativePathOf handles relative input paths" {
+            // This test case covers the bug where Uri constructor throws
+            // UriFormatException for paths it can't determine the format of
+            let fromPath = "myproj/"
+            let toPath = "myproj/src/File.fs"
+
+            let result = VisualTree.relativePathOf fromPath toPath
+            Expect.equal result "src/File.fs" "should handle relative paths"
+        }
+    ]
+
 let tests toolsPath =
     let testSample3WorkspaceLoaderExpected = [
         ExpectNotification.loading "c1.fsproj"


### PR DESCRIPTION
Originally observed in FSharp.Analyzers.SDK:

```
> dotnet fsdocs build --projects
src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsproj
src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fsproj
--properties Configuration=Release --eval --clean --strict
cracking projects...
  skipping project 'FSharp.Analyzers.SDK.fsproj' because an error occurred while cracking it:
System.UriFormatException: Invalid URI: The format of the URI could not be determined.
   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind, UriCreationOptions&
creationOptions)
   at System.Uri..ctor(String uriString)
   at Ionide.ProjInfo.VisualTree.relativePathOf(String fromPath, String toPath) in
/_//src/Ionide.ProjInfo/VisualTree.fs:line 23
   at Ionide.ProjInfo.VisualTree.visualPathVSBehaviour(String projPath, String filePath) in
/_//src/Ionide.ProjInfo/VisualTree.fs:line 33
   at Ionide.ProjInfo.VisualTree.getVisualPath(FSharpOption`1 linkMetadata, FSharpOption`1
fullpathMetadata, String identity, String projPath) in /_//src/Ionide.ProjInfo/VisualTree.fs:line 60
   at Ionide.ProjInfo.VisualTree.getCompileProjectItem(FSharpList`1 projItems, String projPath, String
sourceFile) in /_//src/Ionide.ProjInfo/VisualTree.fs:line 82
   at Ionide.ProjInfo.ProjectLoader.compileItems@752.Invoke(String sourceFile)
   at Microsoft.FSharp.Primitives.Basics.List.map[T,TResult](FSharpFunc`2 mapping, FSharpList`1 x) in
D:\a\_work\1\s\src\FSharp.Core\local.fs:line 245
   at Microsoft.FSharp.Collections.ListModule.Map[T,TResult](FSharpFunc`2 mapping, FSharpList`1 list)
in D:\a\_work\1\s\src\FSharp.Core\list.fs:line 97
   at Ionide.ProjInfo.ProjectLoader.mapToProject(String path, IEnumerable`1 compilerArgs, IEnumerable`1
 p2p, IEnumerable`1 compile, IEnumerable`1 nugetRefs, ProjectSdkInfo sdkInfo, IEnumerable`1 props,
IEnumerable`1 customProps) in /_//src/Ionide.ProjInfo/Library.fs:line 750
   at Ionide.ProjInfo.ProjectLoader.getLoadedProjectInfo(String path, FSharpList`1 customProperties,
LoadedProject project) in /_//src/Ionide.ProjInfo/Library.fs:line 831
   at Ionide.ProjInfo.ProjectLoader.getProjectInfo(String path, FSharpList`1 globalProperties,
BinaryLogGeneration binaryLogs, FSharpList`1 customProperties) in
/_//src/Ionide.ProjInfo/Library.fs:line 845
   at fsdocs.Crack.crackProjectFileAndIncludeTargetFrameworks[a](a _slnDir, FSharpList`1
extraMsbuildProperties, String projectFile) in
/home/runner/work/FSharp.Formatting/FSharp.Formatting/src/fsdocs-tool/ProjectCracker.fs:line 290
   at fsdocs.Crack.crackProjectFile[a](a slnDir, FSharpList`1 extraMsbuildProperties, String file) in
/home/runner/work/FSharp.Formatting/FSharp.Formatting/src/fsdocs-tool/ProjectCracker.fs:line 379
   at fsdocs.Crack.projectInfos@484.Invoke(String p) in
/home/runner/work/FSharp.Formatting/FSharp.Formatting/src/fsdocs-tool/ProjectCracker.fs:line 486
Project cracking failed and --strict is on, exiting
```

The new test at line 2521 fails while the bug exists.

[Path.GetRelativePath](https://learn.microsoft.com/en-us/dotnet/api/system.io.path.getrelativepath?view=netstandard-2.1) is in netstandard2.1; ProjInfo [targets net8.0](https://github.com/ionide/proj-info/blob/47234f39825f23c387f8321a68f4450e20b5454b/src/Ionide.ProjInfo/Ionide.ProjInfo.fsproj#L4) at minimum.

Tests generated by Claude; if you like, I can cut them down to just the one that demonstrates the bug this PR fixes.